### PR TITLE
Include the "Keyboard Controllers" page in the docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -155,6 +155,7 @@ pages:
     - PS3: PS3-Controller.md
     - 8Bitdo: 8Bitdo-Controller.md
     - Bluetooth: Bluetooth-Controller.md
+    - Keyboard Controllers: Keyboard-Controllers.md
     - Logitech: Logitech-Controller.md
     - N64: N64-Controller.md
     - PS4: PS4-Controller.md


### PR DESCRIPTION
The page is only available in the Wiki and contains useful information.