### PR TITLE
update mkdocs.yml for mkdocs 5.x compatibility

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,9 +29,9 @@ theme:
 # Customisation
 extra:
   social:
-    - type: 'github'
+    - icon:  fontawesome/brands/github-alt
       link: 'https://github.com/RetroPie'
-    - type: 'twitter'
+    - icon:  fontawesome/brands/twitter
       link: 'https://twitter.com/retropieproject'
 
 extra_css:


### PR DESCRIPTION
Changes need for [Upgrading to the 5.x](https://squidfunk.github.io/mkdocs-material/releases/5/#extrasocial) release of the Material Mkdocs theme.