### PR TITLE
Correct `Enable SSH` documentation

### DIFF
--- a/docs/SSH.md
+++ b/docs/SSH.md
@@ -6,7 +6,7 @@ SSH stands for secure shell. You can remotely connect to the raspberry pi termin
 
 **Note:** Starting with RetroPie 4.2, in order to keep the default image secure, SSH is disabled by default. It can be enabled in either of the two ways listed below.
 
-1) Pre-boot. From a system with an SD-card reader, access the **/boot/** directory and create an empty file called `ssh`.
+1) Pre-boot. On a system with an SD-card reader, access your SD-card and create an empty file called `ssh` in the root directory of the **boot** partition.
 
 2) In **raspi-config**: after booting.
 ```


### PR DESCRIPTION
To enable SSH, a `ssh` should be put at the root of the boot partition, not in the `/boot` directory of the retropie partition.