### PR TITLE
Removed arcade and PSP compatibility lists due to vandalisation/bad edits

### DIFF
--- a/docs/Arcade.md
+++ b/docs/Arcade.md
@@ -31,12 +31,12 @@ In general, you will only get good results with a full set of ROMs. Incomplete R
 
 There are a number of different rom set versions. Different versions contain different games (although there's plenty of overlap). This table tells you which rom set version you need for each emulator, and which games are in each set:
 
-| Emulator | Required ROM Version | # of ROMs | Compatibility List |
+| Emulator | Required ROM Version | # of ROMs |
 | :---: | :---: | :---: | :---: |
-| [mame4all](MAME) | MAME 0.37b5 | 2270 | [List](https://docs.google.com/spreadsheets/d/1SHspjyHavY9-PKbO2swDr52BS2Wl_mB_Vjx2Z1SXiD8/edit) |
-| [lr-mame2003](MAME) | MAME 0.78 | 4720 | [List](https://docs.google.com/spreadsheets/d/1LP1MELCvcxu7TfiowF_0ZuvRVEMqlfQyTVetnOJvuJc/edit?usp=sharing) |
-| [pifba](FinalBurn-Neo#pifba) | FB Alpha v0.2.96.71 | 684 | [List](https://docs.google.com/spreadsheets/d/1OZioLrz16ptaNbjQUDP5hhVzQDTOTn9Nz46Hbj3-06k/edit?usp=sharing) |
-| [lr-fbneo](FinalBurn-Neo) | FB Neo v0.2.97.44-WIP | 4896 | [List](https://docs.google.com/spreadsheets/d/1GaqIIoiWbzKHwZ52S2xCSDQXILo81Ls1mHK6czKGAtM/edit?usp=sharing) |
+| [mame4all](MAME) | MAME 0.37b5 | 2270 |
+| [lr-mame2003](MAME) | MAME 0.78 | 4720 |
+| [pifba](FinalBurn-Neo#pifba) | FB Alpha v0.2.96.71 | 684 |
+| [lr-fbneo](FinalBurn-Neo) | FB Neo v0.2.97.44-WIP | 4896 |
 
 To sum up, for best results:
 

--- a/docs/FinalBurn-Neo.md
+++ b/docs/FinalBurn-Neo.md
@@ -12,8 +12,6 @@ There are a variety of arcade emulators available in RetroPie. There are signifi
 
 This page is a resource for additional details on RetroPie's FinalBurn emulators including configuration paths, controls, and the ROM sets required by each emulator.
 
-[**All Arcade ROMS Compatibility List**](https://docs.google.com/spreadsheets/d/1antILt7D12EWOFzyJwTfB86NceghMJKXG7CdYumuHec/edit?usp=sharing) feel free to contribute to the list.
-
 | Emulator | Rom Folder | Extension | Required ROM Version | Controller Config |
 | :---: | :---: | :---: | :---: | :---: |
 | [lr-fbneo](#lr-fbneo) | arcade **or** fba **or** neogeo  | .7z .zip | FB Neo v0.2.97.44| /opt/retropie/configs/arcade/retroarch.cfg, **or** /opt/retropie/configs/fba/retroarch.cfg, **or** /opt/retropie/configs/neogeo/retroarch.cfg |
@@ -70,8 +68,6 @@ NOTE: If you have updated RetroPie from an existing installation since 27th May 
 
 [Other Dats for home console systems available here](https://github.com/libretro/fbeo/tree/master/dats)
 
-[lr-fbneo compatibility list](https://docs.google.com/spreadsheets/d/1GaqIIoiWbzKHwZ52S2xCSDQXILo81Ls1mHK6czKGAtM/edit?usp=sharing) feel free to contribute to the list.
-
 **Controls:**
 lr-fbneo utilises RetroArch configs. Add custom retroarch controls to the retroarch.cfg file in:
 ```shell
@@ -104,8 +100,6 @@ Config Dir: /opt/retropie/configs/fba/retroarch.cfg
 
 **FB Alpha v0.2.97.30 Neo Geo Only DAT File**: [fba-lr-neogeo](https://drive.google.com/file/d/0B2TMeZ6iEFvHVk1Ud1RoSHpfcFU/view?usp=sharing)
 
-[**lr-fbalpha2012 Compatibility List**](https://docs.google.com/spreadsheets/d/1rWO7Lm0bTGNpak6J-CPzde0GNIDP0NHDoQdJ6iWosfA/edit?usp=sharing)  feel free to contribute to the list.
-
 **Controls:**
 lr-fbalpha2012 utilises RetroArch configs. Add custom retroarch controls to the retroarch.cfg file in:
 ```shell
@@ -134,8 +128,6 @@ Config Dir: /opt/retropie/configs/fba/fba2x.cfg
 **FB Alpha v0.2.96.71 DAT File**: [FB Alpha v0.2.96.71 (ClrMame Pro).dat](https://drive.google.com/file/d/0B2TMeZ6iEFvHZFJOckQyRVZ5OG8/view?usp=sharing)
 
 **FB Alpha v0.2.96.71 'Lite' DAT File**: [fba_029671_od_release_10_working_roms_filtered.zip] (https://drive.google.com/file/d/0B2TMeZ6iEFvHMTV2TnlrZWwxRXc/view?usp=sharing) (clones, non-working, mahjong, quiz, adult, casino, rythm removed)
-
-[**PiFBA Compatibility List**](https://docs.google.com/spreadsheets/d/1OZioLrz16ptaNbjQUDP5hhVzQDTOTn9Nz46Hbj3-06k/edit?usp=sharing)  feel free to contribute to the list.
 
 **Controls**
 

--- a/docs/MAME.md
+++ b/docs/MAME.md
@@ -11,8 +11,6 @@ There are a variety of arcade emulator versions available in RetroPie. There are
 
 This page is a resource for additional details on RetroPie's MAME emulators including configuration paths, controls, and the ROM sets which each emulator requires.
 
-**All Arcade ROMS Compatibility List**: [Google Drive document](https://docs.google.com/spreadsheets/d/1antILt7D12EWOFzyJwTfB86NceghMJKXG7CdYumuHec/edit?usp=sharing).
-
 | Emulator | ROM Folder(s) | Extension | Required ROM Set Version
 | :---: | :---: | :---: | :--- |
 | [mame4all-pi](#mame4all-pi) | arcade **or** mame-mame4all | .zip | MAME 0.37b5 
@@ -55,8 +53,6 @@ To avoid having several menus for different arcade emulators, all arcade-based R
 * CHDs: 0
 * Samples: 35
 
-**Based on the MAME4ALL-PI Compatibility list below:**
-
 * 1126 Parent Roms
 * 1025 Clones Roms
 * 129 NeoGeo Roms (Parent+Clone)
@@ -64,8 +60,6 @@ To avoid having several menus for different arcade emulators, all arcade-based R
 **MAME 0.37b5 DAT File**: [mame4all-037b5-RetroPie-260.dat](https://drive.google.com/file/d/0B2TMeZ6iEFvHVUNfWHpUZk82bkk/view?usp=sharing)
 
 **MAME 0.37b5 XML File**: [mame4all-no-clones-no-neogeo](https://drive.google.com/file/d/0B2TMeZ6iEFvHNm5OYndFUHM3djg/view?usp=sharing) Does not include clones or NeoGeo romsets.
-
-**MAME4ALL-PI Compatibility List**: [Google Drive document](https://docs.google.com/spreadsheets/d/1SHspjyHavY9-PKbO2swDr52BS2Wl_mB_Vjx2Z1SXiD8/edit?usp=sharing)
 
 #### Controls
 
@@ -100,8 +94,6 @@ _**Note**_: If configuration or other aspect of the configuration need resetting
 
 **MAME 0.37b5 'Lite' DAT File**: [mame4all-no-clones-no-neogeo](https://drive.google.com/file/d/0B2TMeZ6iEFvHNm5OYndFUHM3djg/view?usp=sharing) - Does not include clones or NeoGeo romsets.
 
-**[lr-mame2000 Compatibility List](https://docs.google.com/spreadsheets/d/1Fmx2RPcgVgIIeKpaBKNEGWCDuu3DGfR-VkrnIVsIpeE/edit?usp=sharing)** feel free to contribute to the list.
-
 #### Controls
 
 MAME 2000 uses [RetroArch control configuration](RetroArch-Configuration). Custom Retroarch controls can be added to the `retroarch.cfg` file in
@@ -135,8 +127,6 @@ Please see **[MAME 2003 on RetroPie](lr-mame2003)** for information on how to co
 **MAME 0.78u5 DAT File**: [mame2003-lr-working-no-clones](https://drive.google.com/file/d/0B2TMeZ6iEFvHV21wRVh6TF9uQ1U/view?usp=sharing) - Working romsets only. Does not include clones.
 
 **MAME 0.78u5 'Lite' DAT File**: [mame2003-lr-lite](https://drive.google.com/file/d/0B2TMeZ6iEFvHY1VzcXYyT09iRGs/view?usp=sharing) - Working romsets only. Does not include: clones, NeoGeo, PlayChoice NES/multiplay, romsets with rotary/dial/trackball/light gun controls, or romsets classified as casino/quiz/mahjong/fruit_machines/rhythm/mature.
-
-**Mame 2003 Compatibility List**: [Google Drive document](https://docs.google.com/spreadsheets/d/1LP1MELCvcxu7TfiowF_0ZuvRVEMqlfQyTVetnOJvuJc/edit?usp=sharing)
 
 **[Mame 2003 catver.ini](https://github.com/libretro/mame2003-libretro/blob/master/metadata/catver.ini)** also contains data on games definitively known not to work, as well as sorting data for mature games and other, less desirable, romsets.
 
@@ -216,8 +206,6 @@ MAME 2003-Plus uses both [RetroArch control configuration](RetroArch-Configurati
 * Samples: 70 (4 more samples are not in circulation)
 
 **MAME 0.139 DAT File**: [MAME 0.139.dat](https://raw.githubusercontent.com/libretro/mame2010-libretro/master/metadata/mame2010.xml) 
-
-**MAME 2010 Compatibility List**: [Google Drive document](https://docs.google.com/spreadsheets/d/1IRSmFrSDvIc6gAw0gn12TcQ3HDOwmrETTor8wvvb7VI/edit#gid=1947139826)
 
 #### Controls
 
@@ -341,8 +329,6 @@ MAME 2016 uses [RetroArch control configuration](RetroArch-Configuration). Custo
 
 **AdvanceMAME 0.94 DAT File**: [advmame-0.94-RetroPie-260.7z](https://drive.google.com/file/d/0B2TMeZ6iEFvHa2E5Rzl4ZEdMdjQ/view?usp=sharing)
 
-**[AdvanceMAME 0.94 Compatibility List]**: [Google Drive document](https://docs.google.com/spreadsheets/d/1AEQ94buG0rvbW0xdnYKeuEhHeCbuZlRfRJQCb1Dt8fw/edit?usp=sharing)
-
 #### Controls
 
 While in a game, press <kbd>Tab</kbd> to open the menu and set up controls. AdvanceMAME configuration for controls is stored in `/opt/retropie/configs/mame-advmame/advmame-0.94.0.rc`. Changes to specific games result in `.rc` file entries with a prefix for the ROM (i.e. `bwidow/input_map[p1_doubleleft_up] keyboard[0,up]` for the `bwidow` game).
@@ -369,8 +355,6 @@ _**Note**_: The `.rc` file can also be edited manually, with a text editor. Any 
 * Samples: 64 (3 more samples are not in circulation)
 
 **AdvanceMAME 1.4 DAT File**: [advmame12-106.7z](https://drive.google.com/file/d/0B2TMeZ6iEFvHMEZnb1RxQWNmdHM/view?usp=sharing)
-
-**AdvanceMAME 1.4 Compatibility**: [Google Drive document](https://docs.google.com/spreadsheets/d/1RapyxChe2BMOfbX-FsCup9SXGxvS1WmXAofwaTJtmxc/edit?usp=sharing)
 
 #### Controls
 

--- a/docs/Neo-Geo.md
+++ b/docs/Neo-Geo.md
@@ -154,8 +154,6 @@ Config Dir: /opt/retropie/configs/neogeo
 **GnGeo-Pi Filtered DAT File**: [pandora_gngeo_084_filtered.zip](https://drive.google.com/file/d/0B2TMeZ6iEFvHb1RhaTF0NzJaRlU/view?usp=sharing)All clones non-working\mahjong\quiz removed    
 **Romsets emulated**: 128
 
-[**GnGeo-Pi Compatibility List**](https://docs.google.com/spreadsheets/d/1A_a_9t14uzDUMrrO0RgLDwiVUiycmclcPIs6cU6Iox8/edit?usp=sharing)  feel free to contribute to the list.
-
 As a caveat, if you're using _gngeo-pi__, the ROMs you have must match the file in `gngeo_data.zip` located at:
 ```
 /opt/retropie/emulators/gngeopi/share/gngeo

--- a/docs/PSP.md
+++ b/docs/PSP.md
@@ -20,7 +20,6 @@ Place your PSP ROMs in
 ```
 /home/pi/RetroPie/roms/psp
 ```
-#### [**PSP COMPATIBILITY LIST**](https://docs.google.com/spreadsheets/d/1V-MEx1tOXqCcJL1fQzGh9xLHny-qL-PSWqvY7F80Y90/edit?usp=sharing) feel free to contribute! 
 
 ## Controls
 


### PR DESCRIPTION
These lists are not feasible to keep valid with the sharing tools google provides. There's nothing stopping bots/users creating new sheets, or filling the notes field with garbage, or indeed giving bad compatibility data (eg, when using a wrong romset).

Rather than keep resetting them back to known-good versions (I'm not even sure what those would be anymore), I think it's time to retire them. For the most part arcade cores should support every game within their `WORKING` rom set anyway, and some cores display warnings if emulation is incomplete, etc.

I've left some of the console sheets (N64, Dreamcast, etc) that I'm hosting up as users seem to be actively using them, but I fancy they to will eventually have to go. PSP is a mess.