### PR TITLE
Update Transferring-Roms.md

### DIFF
--- a/docs/Transferring-Roms.md
+++ b/docs/Transferring-Roms.md
@@ -1,10 +1,10 @@
 ROM stands for *Read Only Memory*. In a RetroPie context, ROMs are digital copies of games which can be run on emulators (software that mimics your old gaming consoles). There are many issues involving copyright laws regarding the usage of ROMs, so in order to preserve the integrity and longevity of the RetroPie project, the download locations of ROMs will not and cannot be added to the Wiki. That being said, in the search of your childhood - Google is your friend.
 
-# Transferring ROMs
+## Transferring ROMs
 
 There are three main methods of transferring ROMs: via USB stick, via SFTP, and via Windows (Samba) shares.
 
-## USB stick
+### USB stick
 
 1. Ensure that the USB stick is formatted to FAT32 or exFAT, and that the SD card has enough free space to hold all ROMs
 2. Create a folder called `retropie` on the USB stick
@@ -16,11 +16,11 @@ There are three main methods of transferring ROMs: via USB stick, via SFTP, and 
 9. Refresh the game listing in EmulationStation by pressing F4, or press **Start** on your controller > **Quit** > **Restart EmulationStation**
 10. The transferred games should now be visible within EmulationStation. If any are missing, return to step 6
 
-## SFTP
+### SFTP
 
 SFTP/SSH connection instructions are available on the [SSH page](SSH.md). Once you've enabled SSH and connected to your chosen client, you can simply drop the files in the `~/RetroPie/roms/$CONSOLE` folder, where $CONSOLE is the name of the target console, e.g. `snes` or `arcade`.
 
-## Samba-Shares
+### Samba-Shares
 
 [Samba](https://www.samba.org/samba/what_is_samba.html) is a software suite that allows you to access file systems over the network. Naturally both your PC and Pi will need to be connected to the same network via Ethernet or Wifi in order to successfully transfer your files. 
 
@@ -30,11 +30,11 @@ SFTP/SSH connection instructions are available on the [SSH page](SSH.md). Once y
 
 - On Mac OS X/macOS, open Finder, select "Go" menu and "Connect to Server". Type `smb://retropie` and hit "Connect".
 
-## Manually copy files from USB-stick
+### Manually copy files from USB-stick
 
 RetroPie version 3.0+ contains a file manager. It allows you to manually transfer files between USB-stick and Raspberry Pi SD card. The file manager can be run from 'RetroPie' EmulationStation menu > **File Manager**. A Midnight Commander file manager guide can be found [here](http://www.thegeekstuff.com/2008/10/midnight-commander-mc-guide-powerful-text-based-file-manager-for-unix/). Your USB-stick should be mounted in `/media/usb`. The directories for the ROM files are located in `retropie/roms/$CONSOLE` folder, where $CONSOLE is the name of the target console, e.g. `snes` or `arcade`.
 
-# Alternative Methods of Accessing Games
+## Alternative Methods of Accessing Games
 
 - [Running ROMs From a USB](Running-ROMs-from-a-USB-drive)
 - [Running ROMs From a Network Share](Running-ROMs-from-a-Network-Share)

--- a/docs/Transferring-Roms.md
+++ b/docs/Transferring-Roms.md
@@ -1,12 +1,10 @@
-# ROMS
-
 ROM stands for *Read Only Memory*. In a RetroPie context, ROMs are digital copies of games which can be run on emulators (software that mimics your old gaming consoles). There are many issues involving copyright laws regarding the usage of ROMs, so in order to preserve the integrity and longevity of the RetroPie project, the download locations of ROMs will not and cannot be added to the Wiki. That being said, in the search of your childhood - Google is your friend.
 
-## Transferring Roms
+# Transferring ROMs
 
-There are three main methods of transferring roms: via USB stick, via SFTP, and via Windows (Samba) shares.
+There are three main methods of transferring ROMs: via USB stick, via SFTP, and via Windows (Samba) shares.
 
-### USB stick
+## USB stick
 
 1. Ensure that the USB stick is formatted to FAT32 or exFAT, and that the SD card has enough free space to hold all ROMs
 2. Create a folder called `retropie` on the USB stick
@@ -18,47 +16,11 @@ There are three main methods of transferring roms: via USB stick, via SFTP, and 
 9. Refresh the game listing in EmulationStation by pressing F4, or press **Start** on your controller > **Quit** > **Restart EmulationStation**
 10. The transferred games should now be visible within EmulationStation. If any are missing, return to step 6
 
-### SFTP
+## SFTP
 
-SFTP (Secure File Transfer Protocol) is a network protocol that allows you to securely transfer files over the internet or locally on the same network when both your PC and RetroPie system are connected to the same router via Ethernet or Wifi. 
+SFTP/SSH connection instructions are available on the [SSH page](SSH.md). Once you've enabled SSH and connected to your chosen client, you can simply drop the files in the `~/RetroPie/roms/$CONSOLE` folder, where $CONSOLE is the name of the target console, e.g. `snes` or `arcade`.
 
-- Wired (needs ethernet cable)
-- Wireless (Raspberry Pi Zero W, 3 and 4 models have onboard Wifi, so Pi 1 and 2 will need a dongle)
-
-To enable SSH from within RetroPie:
-
-1. Within the 'RetroPie' EmulationStation options menu, select **raspi-config**
-2. Select **Interface Options**
-3. Select **SSH**
-4. Choose **Yes**
-5. Select **Ok**
-6. Choose **Finish**
-
-There are many SFTP programs out there:
-
-- Windows: 
-  - [WinSCP](https://winscp.net/eng/download.php) - For easy drag & drop file transfer
-  - [MobaXTerm](https://mobaxterm.mobatek.net/) - Feature-rich command line access and drag & drop file transfer
-- Mac: [Cyberduck](https://cyberduck.io/?l=en)
-
-![ftp](https://cloud.githubusercontent.com/assets/10035308/9144892/68994618-3d0d-11e5-8db0-2991f9068115.png)
-
-**Connection settings** 
-
-- Protocol: `SFTP`
-- IP address/Host Name: To find the IP address of your RetroPie, go into the 'RetroPie' EmulationStation options menu and select **Show IP**. You can also find this information from the terminal on RetroPie in the bash info or with the command `ifconfig`
-- Username: `pi` (default)
-- Password: `raspberry` (default)
-
-**Where to drop the files**
-
-Simply drop the files in the `~/RetroPie/roms/$CONSOLE` folder, where $CONSOLE is the name of the target console, e.g. `snes` or `arcade`.
-
-You can also log in as root if you wish to change more files than just the roms, but you first need to enable the root password by typing `sudo passwd root` into the terminal and choosing a new root password.
-
-For more information, check the [Raspberry Pi SSH documentation](https://www.raspberrypi.org/documentation/remote-access/ssh/).
-
-### Samba-Shares
+## Samba-Shares
 
 [Samba](https://www.samba.org/samba/what_is_samba.html) is a software suite that allows you to access file systems over the network. Naturally both your PC and Pi will need to be connected to the same network via Ethernet or Wifi in order to successfully transfer your files. 
 
@@ -68,11 +30,11 @@ For more information, check the [Raspberry Pi SSH documentation](https://www.ras
 
 - On Mac OS X/macOS, open Finder, select "Go" menu and "Connect to Server". Type `smb://retropie` and hit "Connect".
 
-### Manually copy files from USB-stick
+## Manually copy files from USB-stick
 
 RetroPie version 3.0+ contains a file manager. It allows you to manually transfer files between USB-stick and Raspberry Pi SD card. The file manager can be run from 'RetroPie' EmulationStation menu > **File Manager**. A Midnight Commander file manager guide can be found [here](http://www.thegeekstuff.com/2008/10/midnight-commander-mc-guide-powerful-text-based-file-manager-for-unix/). Your USB-stick should be mounted in `/media/usb`. The directories for the ROM files are located in `retropie/roms/$CONSOLE` folder, where $CONSOLE is the name of the target console, e.g. `snes` or `arcade`.
 
-## Alternative Methods of Accessing Games
+# Alternative Methods of Accessing Games
 
 - [Running ROMs From a USB](Running-ROMs-from-a-USB-drive)
 - [Running ROMs From a Network Share](Running-ROMs-from-a-Network-Share)

--- a/docs/Transferring-Roms.md
+++ b/docs/Transferring-Roms.md
@@ -18,7 +18,7 @@ There are three main methods of transferring ROMs: via USB stick, via SFTP, and 
 
 ### SFTP
 
-SFTP/SSH connection instructions are available on the [SSH page](SSH.md). Once you've enabled SSH and connected to your chosen client, you can simply drop the files in the `~/RetroPie/roms/$CONSOLE` folder, where $CONSOLE is the name of the target console, e.g. `snes` or `arcade`.
+SFTP/SSH connection instructions are available on the [SSH page](SSH). Once you've enabled SSH and connected to your chosen client, you can simply drop the files in the `~/RetroPie/roms/$CONSOLE` folder, where $CONSOLE is the name of the target console, e.g. `snes` or `arcade`.
 
 ### Samba-Shares
 

--- a/docs/Transferring-Roms.md
+++ b/docs/Transferring-Roms.md
@@ -18,9 +18,9 @@ There are three main methods of transferring ROMs: via USB stick, via SFTP, and 
 
 ### SFTP
 
-SFTP (Secure File Transfer Protocol) is a network protocol that allows you to securely transfer files over the internet or locally on the same network when both the PC and RetroPie system are connected to the same router via ethernet or wifi using a program like WinSCP. 
+SFTP (Secure File Transfer Protocol) is a network protocol that allows you to securely transfer files over the internet or locally on the same network when both the PC and RetroPie system are connected to the same router via ethernet or wifi. 
 
-[SFTP/SSH connection instructions are available on the SSH page](SSH). Once you've enabled SSH and connected to your chosen client (Recommended: WinSCP), you can simply drop the files in the `~/RetroPie/roms/$CONSOLE` folder, where $CONSOLE is the name of the target console, e.g. `snes` or `arcade`.
+SFTP/SSH connection instructions are available on the [SSH page](SSH). Once you've enabled SSH and connected to your chosen client, you can simply drop the files in the `~/RetroPie/roms/$CONSOLE` folder, where $CONSOLE is the name of the target console, e.g. `snes` or `arcade`.
 
 ### Samba-Shares
 

--- a/docs/Transferring-Roms.md
+++ b/docs/Transferring-Roms.md
@@ -18,7 +18,9 @@ There are three main methods of transferring ROMs: via USB stick, via SFTP, and 
 
 ### SFTP
 
-SFTP/SSH connection instructions are available on the [SSH page](SSH). Once you've enabled SSH and connected to your chosen client, you can simply drop the files in the `~/RetroPie/roms/$CONSOLE` folder, where $CONSOLE is the name of the target console, e.g. `snes` or `arcade`.
+SFTP (Secure File Transfer Protocol) is a network protocol that allows you to securely transfer files over the internet or locally on the same network when both the PC and RetroPie system are connected to the same router via ethernet or wifi using a program like WinSCP. 
+
+[SFTP/SSH connection instructions are available on the SSH page](SSH). Once you've enabled SSH and connected to your chosen client (Recommended: WinSCP), you can simply drop the files in the `~/RetroPie/roms/$CONSOLE` folder, where $CONSOLE is the name of the target console, e.g. `snes` or `arcade`.
 
 ### Samba-Shares
 


### PR DESCRIPTION
Proposed edit for the Transferring ROMs page, moving the SFTP/SSH instruction to the SSH page. 

~Also, I've been tweaking the headers so that top-level headers have one # and sub-headers have two ##, but I'm beginning to wonder if this is a mistake after looking into the Mkdocs header baselevels. Should we start with headers at two ##? If so, this would be good to add to a "How to Contribute" section.~