### PR TITLE
Update Updating-RetroPie.md

### DIFF
--- a/docs/Updating-RetroPie.md
+++ b/docs/Updating-RetroPie.md
@@ -15,7 +15,7 @@ It can also be accessed from the terminal with `sudo ~/RetroPie-Setup/retropie_s
 
 ## Update All Installed Packages
 
-![setup_script](https://cloud.githubusercontent.com/assets/10035308/17758599/fb76e94a-64ad-11e6-8dc6-e8ca545e2630.png)
+![update](https://user-images.githubusercontent.com/540857/106713057-e03e2b00-65c7-11eb-9529-766986334e8b.png)
 
 - **Basic Install:** This is intended as a first install and is not required if using a pre-built image. eg When installing RetroPie on top of an existing OS.
 - **Update All Installed Packages:** This will update the RetroPie-Setup script and all installed packages.

--- a/docs/Updating-RetroPie.md
+++ b/docs/Updating-RetroPie.md
@@ -18,7 +18,7 @@ It can also be accessed from the terminal with `sudo ~/RetroPie-Setup/retropie_s
 ![update](https://user-images.githubusercontent.com/540857/106713057-e03e2b00-65c7-11eb-9529-766986334e8b.png)
 
 - **Basic Install:** This is intended as a first install and is not required if using a pre-built image. eg When installing RetroPie on top of an existing OS.
-- **Update All Installed Packages:** This will update the RetroPie-Setup script and all installed packages.
+- **Update:** This will update the RetroPie-Setup script and all installed packages.
 - **Manage Packages:** This will allow you to install and update individual emulators, ports, controller drivers (like the ps3 or xboxdrv) other optional packages.
 - **Configuration / Tools:** Configuration and tools including BlueTooth and WiFi setup, splashscreens and theme. You can also access any packages that have additional configuration here.
 - **Update RetroPie-Setup Script:** Updates the RetroPie-Setup script to the latest version.


### PR DESCRIPTION
Just going to update this screenshot of retropie_setup to the latest version and ask a few questions.

That whole section beneath the screenshot feels overkill. It's listing every single option in the script instead of just keeping it relevant to the point of this page - updating. I'm still new to this project so correct me if I'm wrong, but doesn't the `Update` section  update ***everything***, including the retropie-setup script and all optional packages? If so, ideally only that should be mentioned.

After that, I think the "Manage packages" section can certainly be mentioned to update individual things, but with the knowledge that it's not necessary if the user uses the "Update" function (again, correct me if I'm wrong). I think I can cut down a lot of fluff on this page.

I'm not overly familiar with Binary and Source updates so I'd just leave that alone.

I wonder if the Making a Backup section should be it's own page, but not a big deal.  After having used win32diskimager once to try to get 40 GB of a 128 GB SD card flashed onto a 64 GB SD card and failing, I'll probably want to mention that. And after doing some Googlin' and seeing how other people circumvent this SD card limitation by just backing up certain folders, like `/home/pi/RetroPie/roms` and `/opt/retropie/configs/all/emulationstation/gamelists`, I'm thinking of mentioning all the "important" folders but I don't know all of them yet. WinSCP is great at gzipping folders that can be dragged anywhere for backups. Might be worth a mention: https://i.imgur.com/iK5EUsR.png

Thoughts?

On a side note, I'm just randomly picking pages. Is there a page you can think of that needs more help than most? My discord is `GregariousJB#6350` if you're feeling chatty. If not, no worries. I'm content with these little Github love letters if you are.