### PR TITLE
Remove non existing FAQ link from the overview

### DIFF
--- a/docs/Debian.md
+++ b/docs/Debian.md
@@ -76,7 +76,6 @@ You can go into Setup / Configuration and enable autostart as you like.
 - [No audio in Mupen64Plus](#no-audio-in-mupen64plus)
 - [XBOX 360 Controller mappings not working](#xbox-360-controller-mappings-not-working)
 - [SteamOS hack to allow installation](#steamos-hack-to-allow-installation)
-- [How do I get latest graphics drivers](#how-do-i-get-latest-graphics-driver)
 
 ### Emulationstation hangs if shutdown/restart was selected
 


### PR DESCRIPTION
The FAQ entry for `How do I get latest graphics drivers?` was removed in 9b10f7f0f4e1eaca50bc8967461b3eb94ada3784 but without also removing it from the table of contents.