### PR TITLE
5200 Setup - Call retroarch-core-options.cfg from emulator.cfg or will land at Memo Pad

### DIFF
--- a/docs/Atari-800-and-5200.md
+++ b/docs/Atari-800-and-5200.md
@@ -65,12 +65,12 @@ atari800_system = "5200"
 
 Edit `/opt/retropie/configs/atari5200/emulators.cfg` and replace `retroarch.cfg` with `retroarch-core-options.cfg`.
 
-Next, make sure the pi user (and not root) owns each of these files.
+Make sure the _pi_ user (and not root) owns each of these files.
 ```shell
-sudo chown pi:pi /opt/retropie/configs/atari5200/emulators.cfg /opt/retropie/configs/atari5200/retroarch-core-options.cfg`
+sudo chown pi:pi /opt/retropie/configs/atari5200/emulators.cfg /opt/retropie/configs/atari5200/retroarch-core-options.cfg
 ```
 
-You should now be able to launch Atari 5200 ROMs directly from EmulationStation. See "Advanced Config" for solutions to problems booting 5200 games.
+See "Advanced Config" for solutions to problems booting 5200 games.
 
 Please be sure to read through the docs below specific to each emulator version. 
 

--- a/docs/Atari-800-and-5200.md
+++ b/docs/Atari-800-and-5200.md
@@ -48,7 +48,7 @@ Once you have your ROMS and your BIOS files where they belong there is one more 
 ## Atari 5200 setup
 In both emulators, the atari.cfg file is shared between Atari computers and the 5200. In lr-atari800, the core options likewise apply to both by default. However, for either emulator, if you have a core options file in your atari5200 directory, it will let you have separate settings for just the 5200 system.
 
-Make sure you have a file called /opt/retropie/configs/atari5200/retroarch-core-options.cfg with this in it:
+Make sure you have a file called `/opt/retropie/configs/atari5200/retroarch-core-options.cfg` with this in it:
 
 ```shell
 atari800_artifacting = "enabled"
@@ -62,7 +62,15 @@ atari800_resolution = "336x240"
 atari800_sioaccel = "enabled"
 atari800_system = "5200"
 ```
-See "Advanced Config" for solutions to problems booting 5200 games.
+
+Edit `/opt/retropie/configs/atari5200/emulators.cfg` and replace `retroarch.cfg` with `retroarch-core-options.cfg`.
+
+Next, make sure the pi user (and not root) owns each of these files.
+```shell
+sudo chown pi:pi /opt/retropie/configs/atari5200/emulators.cfg /opt/retropie/configs/atari5200/retroarch-core-options.cfg`
+```
+
+You should now be able to launch Atari 5200 ROMs directly from EmulationStation. See "Advanced Config" for solutions to problems booting 5200 games.
 
 Please be sure to read through the docs below specific to each emulator version. 
 


### PR DESCRIPTION
The existing docs request the user to create a retroarch-core-options.cfg file but nowhere else in the doc is it referenced. Before this modification, I would be returned directly to ES when attempting to launch any 5200 ROM. After this mod, I landed at the "Atari Computer - Memo Pad" which is referenced within the doc (Atari 800 BIOS Setup).  After using F1 and working through the Emulator Configuration I am able to launch 5200 games without any issues.

- Tested on RPi3b+ and RPi4.
- Verified each of my BIOS files with MD5sum (match existing docs)
- Copied to /home/pi/RetroPie/BIOS/
- Configured lr-atari800 for correct BIOS locations
- Launching 5200 ROMs from EmulationStation is now successful
- Before successful launch, retroarch-core-options.cfg is 10 lines long (nothing more than docs prescribe)
- After successful launch, retroarch-core-options.cfg is now over 3,000 lines.
- Minor tweaks so that section I modified has files/paths enclosed in backticks (code span) for easier reading.

Negative Test:
Restored emulators.cfg to reference retroarch.cfg - land at Atari Computer - Memo Pad screen.

Added an additional note about checking the ownership of the files after editing - if someone mistakenly (certainly no one I know of) edits them with sudo, you will see a (very brief) note about not being able to write to the retroarch-core-options.cfg file. Easily avoided with a quick check.