### PR TITLE
Update theme pages

### DIFF
--- a/docs/Creating-Your-Own-EmulationStation-Theme.md
+++ b/docs/Creating-Your-Own-EmulationStation-Theme.md
@@ -456,7 +456,7 @@ Open `spare/gb/theme.xml`
 Expand `<view name="system"></view>` and insert the following line:
 ```
 <image name="logo">
-    <path>./logo.png</path>
+    <path>./system.svg</path>
 </image>
 ```
 So it looks like this:

--- a/docs/EmulationStation-Advanced-Theming.md
+++ b/docs/EmulationStation-Advanced-Theming.md
@@ -77,17 +77,13 @@ Properties of the system carousel:
 * `horizontal_wheel` Logos/logotext scrolls left/right but with curvature.
 * `vertical_wheel` Logos/logotext scrolls up/down but with curvature.
 
-`<logoRotation></logoRotation>` **Coming soon**
+`<size></size>` Specifies how big the carousel 'bar' or 'wheel' will be. This has no bearing on how big the logos/logotext will be. Basically only affects the size of the background color of the carousel and how the carousel is positioned.
 
-`<logoRotationOrigin></logoRotationOrigin>` **Coming soon**
+`<maxLogoCount></maxLogoCount>` Specifies the number of systems/logos/logotexts that will appear in the carousel.
 
-`<logoCount></logoCount>` Specifies the number of systems/logos/logotexts that will appear in the carousel.
-
-`<maxLogoCount></maxLogoCount>` **Same thing?**
+`<logoSize></logoSize>` Specifies how big the logo image will be. If the image is sized larger than the carousel `<size>`, the image will be clipped at that value/ position on the screen.
 
 `<logoScale></logoScale>` Specifies how much bigger the currently selected logo/logotext will be. For example, a value of 2 will make the currently selected logo/logotext 2 times bigger than the other logos in the carousel.
-
-`<size></size>` Specifies how big the carousel 'bar' or 'wheel' will be. This has no bearing on how big the logos/logotext will be. Basically only affects the size of the background color of the carousel and how the carousel is positioned.
 
 `<color></color>` Specifies the background color of the carousel using hexadecimal notation. A fourth octet can be added to specify opacity of the background. For example, FFFFFF would make the background white. So would FFFFFFFF. However, FFFFFF00 would make the background white but completely transparent.
 


### PR DESCRIPTION
Removed mention of `logo.png` as this was the only time it was used and it did not match the example shown. 

Removed placeholders for`<logoRotation>`, `<logoRotationOrigin>`, and description of `<logoCount>`, as these do not appear to be documented at all, and break existing EmulationStation themes when tested in a carousel type system view.

Added description for `<logoSize>` attribute.
