### PR TITLE
docs: update Amiga's "IPF Support" section

### DIFF
--- a/docs/Amiga.md
+++ b/docs/Amiga.md
@@ -323,7 +323,18 @@ This allows:
 
 IPF support is done through the CAPSIMG library. To enable it, you have to put the dynamic library called `capsimg.so` (Linux) in RetroArch system directory (`/home/pi/RetroPie/BIOS`).
 
-Compatible CAPSIMG libraries for Windows, macOS and Linux can be found at http://www.softpres.org/download and https://fs-uae.net/download#plugins
+Compatible CAPSIMG libraries for Windows, macOS and Linux can be found at http://www.softpres.org/download and https://fs-uae.net/download#plugins.
+
+If you cannot find CAPSIMG library for your CPU architecture, you can always build `capsimg.so` from the source which is available at https://github.com/FrodeSolheim/capsimg.
+
+```bash
+git clone https://github.com/FrodeSolheim/capsimg
+cd capsimg
+./bootstrap
+/.configure
+make
+cp capsimg.so ~/RetroPie/BIOS
+```
 
 ### Floppy drive sounds
 

--- a/docs/Amiga.md
+++ b/docs/Amiga.md
@@ -331,7 +331,7 @@ If you cannot find CAPSIMG library for your CPU architecture, you can always bui
 git clone https://github.com/FrodeSolheim/capsimg
 cd capsimg
 ./bootstrap
-/.configure
+./configure
 make
 cp capsimg.so ~/RetroPie/BIOS
 ```


### PR DESCRIPTION
Explain how `capsimg.so` library can be built from source. This is useful people who have problems running precompiled `capsimg.so` library. The other use case is Raspberry Pi which uses ARM-based unit and precompiled library for it is missing in downloads.