### PR TITLE
Memory Split: removed redundant Kodi caveat following information from Raspberry Pi engineers.

### DIFF
--- a/docs/Memory-Split.md
+++ b/docs/Memory-Split.md
@@ -19,6 +19,10 @@ You can choose a split from 16/32/64/128/256 (the settings may be different depe
 
 On the Raspberry Pi 4 the 3D component of the GPU has its own memory management unit (MMU), and does not use memory from the `gpu_mem` allocation. Instead memory is allocated dynamically within Linux. Increasing this amount can ***harm*** emulation performance.
 
+#### Kodi
+
+Previously, the FKMS driver still utilised the split for certain media tasks, e.g., hardware video decoding for 4K (HEVC) video. If you have issues with 4K videos in Kodi, upgrade to the latest kernel/firmware, for example via RetroPie-Setup -> Configuration / Tools -> raspbiantools -> Upgrade Rasbina Packages
+
 ### Raspberry Pi 0-3
 
 If you don't use the RetroPie provided image, and you install using the [manual installation method](Manual-Installation), you have to adjust the memory split settings manually before installation to reserve at enough video memory for running Emulationstation without problems. The default values used by the RetroPie image are:

--- a/docs/Memory-Split.md
+++ b/docs/Memory-Split.md
@@ -19,14 +19,6 @@ You can choose a split from 16/32/64/128/256 (the settings may be different depe
 
 On the Raspberry Pi 4 the 3D component of the GPU has its own memory management unit (MMU), and does not use memory from the `gpu_mem` allocation. Instead memory is allocated dynamically within Linux. Increasing this amount can ***harm*** emulation performance.
 
-#### Kodi
-
-The FKMS driver still utilises the split for certain media tasks, e.g., hardware video decoding for 4K (HEVC) video. If you have issues with 4K videos in Kodi, try
-~~~~
-gpu_mem=320
-~~~~
-More information [here](https://raspberrypi.org/forums/viewtopic.php?f=66&t=251645).
-
 ### Raspberry Pi 0-3
 
 If you don't use the RetroPie provided image, and you install using the [manual installation method](Manual-Installation), you have to adjust the memory split settings manually before installation to reserve at enough video memory for running Emulationstation without problems. The default values used by the RetroPie image are:

--- a/docs/Memory-Split.md
+++ b/docs/Memory-Split.md
@@ -21,7 +21,7 @@ On the Raspberry Pi 4 the 3D component of the GPU has its own memory management 
 
 #### Kodi
 
-Previously, the FKMS driver still utilised the split for certain media tasks, e.g., hardware video decoding for 4K (HEVC) video. If you have issues with 4K videos in Kodi, upgrade to the latest kernel/firmware, for example via RetroPie-Setup -> Configuration / Tools -> raspbiantools -> Upgrade Rasbina Packages
+Previously, the FKMS driver still utilised the memory split for certain media tasks, e.g., hardware video decoding for 4K (HEVC) video. If you have issues with 4K videos in Kodi, upgrade to the latest kernel/firmware, for example via _RetroPie-Setup -> Configuration / Tools -> raspbiantools -> Upgrade Raspbian packages_.
 
 ### Raspberry Pi 0-3
 


### PR DESCRIPTION
see https://github.com/raspberrypi/firmware/issues/1603#issuecomment-891251474

(I did consider keeping this info in with a note that it's fixed since the 5.10 kernel, but i think since it's in current apt-get versions maybe it's ok to just remove entirely - what do you think?)