### PR TITLE
add pi4 page to TOC

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -225,6 +225,7 @@ nav:
     - Odroid C1/C2: Odroid-C1-C2.md
     - Odroid XU4: Odroid-XU3-XU4.md
     - OSMC: OSMC.md
+    - Pi 4: Pi4.md
 - Troubleshooting:
     - FAQ: FAQ.md
     - Sound Issues: Sound-Issues.md


### PR DESCRIPTION
looks like this page was missing from the table of contents, so just added it to the platforms page unless someone has a better idea of where to put it