### PR TITLE
Update Spinners,-Trackballs,-Lightguns,-and-other-Mouse-Devices.md

### DIFF
--- a/docs/Spinners,-Trackballs,-Lightguns,-and-other-Mouse-Devices.md
+++ b/docs/Spinners,-Trackballs,-Lightguns,-and-other-Mouse-Devices.md
@@ -46,7 +46,7 @@ or this (RetroArch ver. 1.9.5 or earlier)
 [INFO] [udev] Adding device /dev/input/mouse1 as type ID_INPUT_MOUSE.
 ```
 
-**Interpretation**: Look for the `/dev/input/event*` indexes. In the examples above there are mouselike devices at indexes `0`, `1`, `2`, `3,` `4`, and `5` (first example log) and `0`, and `2` (second example log).
+**Interpretation**: Look for the `/dev/input/event*` indexes. In the examples above there are mouselike devices at event indexes `9`, `14`, `18`, `30,` `31`, and `7` (first example log) and `1`, and `2` (second example log).
 
 **Beware**: The index of a specific device may change depending on what device you have attached to which port. For example, if you boot with an external mouse, it might be detected by `udev` as `mouse#0` and your spinner as `mouse#1`, but if you boot the same system without the external mouse attached, everything might ratchet down (spinner becomes `mouse#0`).
 


### PR DESCRIPTION
Corrected event numbers in example descriptions (was showing numbers of MOUSE indexes, not EVENT indexes).