### PR TITLE
Uniform iframes for embedding video/youtube links.

### DIFF
--- a/docs/8Bitdo-Controller.md
+++ b/docs/8Bitdo-Controller.md
@@ -12,7 +12,7 @@
 This guide will show how to use an 8bitdo controller with RetroPie.
 Please make sure you are using at least RetroPie v4.0, and the **controller firmware versions listed below** (newer versions shouldn't cause an issue). It is not recommended to use beta firmware versions.
 
-Please see the [8bitdo support page](http://support.8bitdo.com) for details on how to upgrade the firmware. Before you upgrade your firmware or attempt to register your controller, please make sure your controller is fully charged.  
+Please see the [8bitdo support page](http://support.8bitdo.com) for details on how to upgrade the firmware. Before you upgrade your firmware or attempt to register your controller, please make sure your controller is fully charged.
 
 #  A quick note about the 8bitdo Zero controller.
 
@@ -24,7 +24,7 @@ It also may help to reset the controller by holding down the select button for 8
 
 # Guide to add your controller
 
-**1)** Run the RetroPie setup script, either through the Emulation Station menu option or via the command line.  
+**1)** Run the RetroPie setup script, either through the Emulation Station menu option or via the command line.
 If you want to run this via the command line, quit Emulation Station by pressing F4 on the keyboard and type this at the command line: `sudo /home/pi/RetroPie-Setup/retropie_setup.sh`
 
 **2)** Choose the "Configuration / Tools" menu choice
@@ -33,7 +33,7 @@ If you want to run this via the command line, quit Emulation Station by pressing
 **3)** Choose the "bluetooth - Configure Bluetooth Devices" menu choice
 ![Bluetooth Menu](https://s22.postimg.cc/ofy9ezdb5/2_Bluetooth_Menu.jpg)
 
-**4)** **Make sure the hack option is turned "off"**  
+**4)** **Make sure the hack option is turned "off"**
 You need to make sure your controller is running the relevant [firmware](8Bitdo-Controller#firmware-versions-for-8bitdo-controllers) for this to work correctly, the versions are shown in this wiki article.
 ![Hack Off](https://s22.postimg.cc/df349yl29/2_5_Turn_hack_off.jpg)
 
@@ -95,11 +95,11 @@ The process will have written various controller configuration files for you.
 The main RetroArch controller file will now be in:
 `/opt/retropie/configs/all/retroarch-joypads/`
 
-Here are some examples of the file that should be written. 
+Here are some examples of the file that should be written.
 
 **FC30 Pro**
 
-[FC30 Pro RetroArch config file](http://pastebin.com/raw/YCj3NW0h) (Firmware 1.69 - 8BitdoFC30Pro.cfg) 
+[FC30 Pro RetroArch config file](http://pastebin.com/raw/YCj3NW0h) (Firmware 1.69 - 8BitdoFC30Pro.cfg)
 
 **SFC30**
 
@@ -111,10 +111,10 @@ Here are some examples of the file that should be written.
 
 ## Video Guide
 
-https://www.youtube-nocookie.com/embed/e2We6AElqg8
+<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/e2We6AElqg8" title="RetroPie 4: Adding an 8bitdo Bluetooth Contoller (August 2016)" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; allowfullscreen"></iframe>
 
 ### Firmware Versions for 8bitdo controllers (June 2017)
-![8bitdo controllers firmware](https://s3.postimg.cc/j47k633fn/8bitdo-firmware.png)  
+![8bitdo controllers firmware](https://s3.postimg.cc/j47k633fn/8bitdo-firmware.png)
 
 You can download new firmware [here](http://support.8bitdo.com) and [here](https://github.com/hughsie/8bitdo-firmware/).
 
@@ -122,5 +122,5 @@ You can download new firmware [here](http://support.8bitdo.com) and [here](https
 Please confirm your firmware version before raising a support ticket
 
 ### Some useful links
-http://support.8bitdo.com  
+http://support.8bitdo.com
 https://github.com/libretro/retroarch-joypad-autoconfig/tree/master/udev

--- a/docs/Add-a-New-System-in-EmulationStation.md
+++ b/docs/Add-a-New-System-in-EmulationStation.md
@@ -1,4 +1,4 @@
-This tutorial is intended for those who wish to add a new system in EmulationStation. For example if you are looking to create a system for favourite games across different platforms or a separate system for roms hacks. 
+This tutorial is intended for those who wish to add a new system in EmulationStation. For example if you are looking to create a system for favourite games across different platforms or a separate system for roms hacks.
 
 If you are looking to create a favourites lists **within** a system, then you may wish to consider the [child-friendly version of EmulationStation](Child-friendly-EmulationStation) which has this feature.
 
@@ -31,7 +31,7 @@ The simplest way of adding a new system in your custom `es_systems.cfg` file is 
 
 `<name>`
 
-This is the short name used by ES internally as well as the text used in the EmulationStation UI unless replaced by an image or logo in the theme. It is advised to choose something short and descriptive, e.g. favourites, hacks. 
+This is the short name used by ES internally as well as the text used in the EmulationStation UI unless replaced by an image or logo in the theme. It is advised to choose something short and descriptive, e.g. favourites, hacks.
 
 `<fullname>`
 
@@ -43,7 +43,7 @@ This is the folder where the roms in your new system will be located. This folde
 
 `<extension> and <command>`
 
-These define the list of extensions that EmulationStation will look for in the rom folder defined in `<path>` and the shell command executed when a game is selected. 
+These define the list of extensions that EmulationStation will look for in the rom folder defined in `<path>` and the shell command executed when a game is selected.
 
 Roms can be launched using shell scripts or the runcommand script. Both methods are involved so it is your choice how you wish to proceed. The entries for these tags are covered [below](Add-a-New-System-in-EmulationStation#step-31-launch-roms-with-the-runcommand-script) so check the steps required if you are unsure which is best for you.
 
@@ -64,7 +64,7 @@ Here is an example entry for a section for rom hacks in a custom `es_systems.cfg
 	<extension>.bin .gen .int .nes .rom .smc .BIN .GEN .INT .NES .ROM .SMC</extension>
 	<command>/opt/retropie/supplementary/runcommand/runcommand.sh 0 _SYS_ hacks %ROM%</command>
 	<theme>hacks</theme>
-</system> 
+</system>
 ```
 Once you have completed your entry for the new system, then save your custom `es_system.cfg` file and place your roms in the folder specified in the `<path>` tag.
 
@@ -90,11 +90,7 @@ Here is the Hacks system using the Carbon theme where only a new vector logo has
 
 ![ES System View Unthemed](https://cloud.githubusercontent.com/assets/8166945/22027062/825e06fc-dcca-11e6-8e7e-8479517dcdae.png)
 
-You can find more information on creating themes and images or logos at the following links:
-
-[Creating Your Own Emulation Theme](Creating-Your-Own-EmulationStation-Theme)
-
-[Video Tutorial on creating Vector (svg) logos from Bitmaps (png)](https://www.youtube.com/watch?v=q9Fk6OzX86U)
+You can find more information on creating themes and images or logos at the following at [Creating Your Own Emulation Theme](Creating-Your-Own-EmulationStation-Theme).
 
 ### Step 3.1. Launch roms with the Runcommand script
 *This is recommended for console games, especially those that use libretro emulators such as those for NES, SNES, Megadrive/Genesis.*
@@ -136,7 +132,7 @@ If you wish to launch your games using shell scripts, then the `<extension>` and
 	<command>%ROM%</command>
 
 
-For each game, a shell script will need to be created in the roms folder as defined in the `<path>` tag  in in your custom `es_systems.cfg` file. 
+For each game, a shell script will need to be created in the roms folder as defined in the `<path>` tag  in in your custom `es_systems.cfg` file.
 
 Using the example from the [Doom Mods](Doom#to-launch-doom-mods-pwads) page, the shell script to launch the Batman Doom mod in pr-boom would be:
 
@@ -155,10 +151,10 @@ You can create individual shell scripts for each game in your new system. When y
 
 ### Troubleshooting
 
-* After making changes to your custom `es_systems.cfg` file, if EmulationStation fails to load or your system does not appear then check the EmulationStation log at `/opt/retropie/configs/all/emulationstation/es_log.txt` for any errors. 
+* After making changes to your custom `es_systems.cfg` file, if EmulationStation fails to load or your system does not appear then check the EmulationStation log at `/opt/retropie/configs/all/emulationstation/es_log.txt` for any errors.
 
 * You can use an [online XML validator](https://www.xmlvalidation.com/) to check for errors in your custom `es_systems.cfg` file though this won't pick up on errors such as incorrect rom paths.
 
 * After restarting EmulationStation, if your new system does not include the roms you were expecting, then check that the extensions are included in the `<extension>` tag in your custom `es_systems.cfg` file. Remember Linux is case-sensitve.
 
-* If a rom doesn't run, then check the runcommand log at `/dev/shm/runcommand.log` for errors. 
+* If a rom doesn't run, then check the runcommand log at `/dev/shm/runcommand.log` for errors.

--- a/docs/Bluetooth-Controller.md
+++ b/docs/Bluetooth-Controller.md
@@ -10,7 +10,7 @@ If it asks you anything about the /etc/udev/rules.d/99-com.rules configuration f
 
 If you want to use a bluetooth dongle with the pi3, you should first disable the onboard BT controller by adding `dtoverlay=pi3-disable-bt` to `/boot/config.txt`, then rebooting and plugging your dongle, which should now work.
 
-# Adding a Bluetooth controller to RetroPie  
+# Adding a Bluetooth controller to RetroPie
 
 The simplest way of setting up a Bluetooth controller is through the Bluetooth Configuration menu of the RetroPie Setup script. There are also manual methods that may vary depending on what Bluetooth controller you are using, some of which are described further below on this page.
 
@@ -18,7 +18,7 @@ You can access the bluetooth configuration menu from the RetroPie Menu of Emulat
 
 ![bluetooth 1](https://cloud.githubusercontent.com/assets/10035308/14411884/129c470c-ff12-11e5-9101-e510424b6e55.PNG)
 
-`1.` **Register and Connect Bluetooth Devices:** You can select your bluetooth device's mac address from here 
+`1.` **Register and Connect Bluetooth Devices:** You can select your bluetooth device's mac address from here
 
 ![bluetooth 2](https://cloud.githubusercontent.com/assets/10035308/14411880/129ba13a-ff12-11e5-8d1a-d3b7f72873e1.PNG)
 
@@ -26,7 +26,7 @@ You can access the bluetooth configuration menu from the RetroPie Menu of Emulat
 
 You will get a window popping up telling you if the connection was successful or not. If it was not successful make sure that you chose the correct mac address, if it still doesn't work you may have to configure it manually (see below).
 
-`2.` **Disconnect Bluetooth Devices:** You can disconnect your bluetooth device from this menu 
+`2.` **Disconnect Bluetooth Devices:** You can disconnect your bluetooth device from this menu
 
 ![bluetooth 5](https://cloud.githubusercontent.com/assets/10035308/14411883/129bef8c-ff12-11e5-98cf-b3c5ac6575e2.PNG)
 
@@ -50,195 +50,195 @@ You will get a window popping up telling you if the connection was successful or
 ***
 
 
-The following guide is geared to using a controller from [8bitdo](http://www.8bitdo.com) but should work with a range of bluetooth devices.  
-The examples below are assuming you have just a keyboard and bluetooth dongle plugged into your Pi.  
-  
-**Controller Firmware**  
-Make sure you have the latest firmware for your controller. You will need a USB cable to do this. The firmware for 8bitdo controllers is here: http://8bitdo.com/Support.html  
+The following guide is geared to using a controller from [8bitdo](http://www.8bitdo.com) but should work with a range of bluetooth devices.
+The examples below are assuming you have just a keyboard and bluetooth dongle plugged into your Pi.
 
-### This section is for Jessie based RetroPie (version 3.4 and later)  
-  
-  
+**Controller Firmware**
+Make sure you have the latest firmware for your controller. You will need a USB cable to do this. The firmware for 8bitdo controllers is here: http://8bitdo.com/Support.html
+
+### This section is for Jessie based RetroPie (version 3.4 and later)
+
+
 <a href="https://www.youtube.com/watch?v=Q4K3h4CIJwA
-" target="_blank"><img src="https://i.ytimg.com/vi_webp/Q4K3h4CIJwA/mqdefault.webp" 
-alt="RetroPie with Bluetooth" width="300" height="190" border="10" /></a>  
-  
-**Video Guide**: https://www.youtube.com/watch?v=Q4K3h4CIJwA  
-  
+" target="_blank"><img src="https://i.ytimg.com/vi_webp/Q4K3h4CIJwA/mqdefault.webp"
+alt="RetroPie with Bluetooth" width="300" height="190" border="10" /></a>
+
+**Video Guide**: https://www.youtube.com/watch?v=Q4K3h4CIJwA
+
 
 ### Step 1 - Pair and connect to controller
-Quit Emulation Station with F4 and type this at the command line:  
-`sudo /home/pi/RetroPie-Setup/retropie_setup.sh`  
-"U" Update RetroPie-Setup Script  
-"3" Setup  
-"Configure Bluetooth devices"  
-  
+Quit Emulation Station with F4 and type this at the command line:
+`sudo /home/pi/RetroPie-Setup/retropie_setup.sh`
+"U" Update RetroPie-Setup Script
+"3" Setup
+"Configure Bluetooth devices"
+
 Make sure your controller is turned on in the correct pairing mode (Power on for FC30 Pro, Start+R for SFC30), then choose:
-1 Register and Connect to Bluetooth device  
-Follow the prompts and your controller should connnect  
-This is shown by a solid blue light on the 8bitdo controllers  
+1 Register and Connect to Bluetooth device
+Follow the prompts and your controller should connnect
+This is shown by a solid blue light on the 8bitdo controllers
 Quit out of the setup script
 
-### Step 2 - Manual file edit for 8bitdo controllers  
-At the command prompt, type  
-`sudo nano /etc/udev/rules.d/10-local.rules`  
-In that file add   
+### Step 2 - Manual file edit for 8bitdo controllers
+At the command prompt, type
+`sudo nano /etc/udev/rules.d/10-local.rules`
+In that file add
 
-`SUBSYSTEM=="input", ATTRS{name}=="8Bitdo SFC30 GamePad Joystick", MODE="0666", ENV{ID_INPUT_JOYSTICK}="1"`  
-Note: The value in the name field should read exactly as your controller reports it.  
-  
-### Step 2.5 - Forcing the Pi to reconnect to the controller 
-**If** you find your controller doesn't automatically reconnect when you restart the Pi, this process should force the connection.  
-Some users have reported it will work without this if you wait for Emulation Station to fully load before turning on your controller - this is possibly model or firmware specific.  
+`SUBSYSTEM=="input", ATTRS{name}=="8Bitdo SFC30 GamePad Joystick", MODE="0666", ENV{ID_INPUT_JOYSTICK}="1"`
+Note: The value in the name field should read exactly as your controller reports it.
 
-`sudo nano /bin/connect-bluetooth.sh`  
- 
-In that file add  
-    `#!/bin/bash`  
-    `sudo bluetoothctl << EOF`  
-    `power on`  
-    `connect [MAC Address]`  
-    `exit`  
+### Step 2.5 - Forcing the Pi to reconnect to the controller
+**If** you find your controller doesn't automatically reconnect when you restart the Pi, this process should force the connection.
+Some users have reported it will work without this if you wait for Emulation Station to fully load before turning on your controller - this is possibly model or firmware specific.
+
+`sudo nano /bin/connect-bluetooth.sh`
+
+In that file add
+    `#!/bin/bash`
+    `sudo bluetoothctl << EOF`
+    `power on`
+    `connect [MAC Address]`
+    `exit`
     `EOF`
 
-Save that file.  
-Make it executable  
-  
-`sudo chmod +x /bin/connect-bluetooth.sh`  
-  
-Then create a new file  
-`sudo nano /etc/systemd/system/connect-bluetooth.service`  
-  
-Add this text:  
-`[Unit]`  
-`Description=Connect Bluetooth`  
-  
-`[Service]`  
-`Type=oneshot`  
-`ExecStart=/bin/connect-bluetooth.sh`  
-  
-`[Install]`  
-`WantedBy=multi-user.target`  
-Save that file.  
-  
-Then run this command to enable that process  
-`sudo systemctl enable /etc/systemd/system/connect-bluetooth.service`
-  
-Video Guide for this: https://youtu.be/RsybSJEPZJM
-  
-### Step 3 - Configure controller for Emulation Station and Retroarch  
-Now reboot your system, turn the controller on just before the RetroPie splashscreen appears and the controller will connect (solid blue led light) and ES will prompt to configure it. 
-  
-  
-  
+Save that file.
+Make it executable
 
-  
-### This section is for Wheezy based RetroPie (pre version 3.4)  
+`sudo chmod +x /bin/connect-bluetooth.sh`
+
+Then create a new file
+`sudo nano /etc/systemd/system/connect-bluetooth.service`
+
+Add this text:
+`[Unit]`
+`Description=Connect Bluetooth`
+
+`[Service]`
+`Type=oneshot`
+`ExecStart=/bin/connect-bluetooth.sh`
+
+`[Install]`
+`WantedBy=multi-user.target`
+Save that file.
+
+Then run this command to enable that process
+`sudo systemctl enable /etc/systemd/system/connect-bluetooth.service`
+
+Video Guide for this: https://youtu.be/RsybSJEPZJM
+
+### Step 3 - Configure controller for Emulation Station and Retroarch
+Now reboot your system, turn the controller on just before the RetroPie splashscreen appears and the controller will connect (solid blue led light) and ES will prompt to configure it.
+
+
+
+
+
+### This section is for Wheezy based RetroPie (pre version 3.4)
 
 <a href="https://www.youtube.com/watch?v=EiDJFdWXweI
-" target="_blank"><img src="https://i.ytimg.com/vi_webp/EiDJFdWXweI/mqdefault.webp" 
-alt="RetroPie with Bluetooth" width="300" height="190" border="10" /></a>  
-  
-**Video Guide**: https://www.youtube.com/watch?v=EiDJFdWXweI  
+" target="_blank"><img src="https://i.ytimg.com/vi_webp/EiDJFdWXweI/mqdefault.webp"
+alt="RetroPie with Bluetooth" width="300" height="190" border="10" /></a>
 
-### Step 1 - Download and install the Bluetooth packages  
-Quit Emulation Station with F4 (stop it restarting by pressing another key within 5 secs) and type this at the command line:  
-`sudo apt update`  
-`sudo apt install bluetooth bluez python-gobject`  
+**Video Guide**: https://www.youtube.com/watch?v=EiDJFdWXweI
 
-### Step 2 - Pairing and connecting the Bluetooth controller  
-Set your Bluetooth controller to pair in "joypad" mode. For example, for the FC30 Pro, you do this by holding the power switch for 3 secs. The guide is here: [FC30 Pro Manual](http://download.8bitdo.com/Manual/FC30_Pro_Manual_ENG_v1.0.pdf)  
-  
-Type this at the command prompt  
-`hcitool scan`  
-This should find your controller and show its name and [MAC](https://en.wikipedia.org/wiki/MAC_address) address  
-  
-Pair the controller with this command, replace the XX data with your MAC address  
-`sudo bluez-simple-agent -c DisplayYesNo hci0 XX:XX:XX:XX:XX:XX`  
-  
-Tell the system to trust your controller so you dont have to pair every time  
-`sudo bluez-test-device trusted XX:XX:XX:XX:XX:XX yes`  
-  
-Then connect to your controller with  
-`sudo bluez-test-input connect XX:XX:XX:XX:XX:XX`  
-  
-Your controller should then connect, with the 8bitdo controllers this is shown by a solid blue light that will begin to glow.  
-  
-### Step 3 - Making sure the connection attempt automatically starts when you reboot your Pi  
-You may find the controller connects on startup without issue, but if not try this. There are different ways to do this, but this should work to start the connection attempt when the Pi starts up.  
-Edit this startup file  
-`sudo nano /etc/rc.local`  
+### Step 1 - Download and install the Bluetooth packages
+Quit Emulation Station with F4 (stop it restarting by pressing another key within 5 secs) and type this at the command line:
+`sudo apt update`
+`sudo apt install bluetooth bluez python-gobject`
+
+### Step 2 - Pairing and connecting the Bluetooth controller
+Set your Bluetooth controller to pair in "joypad" mode. For example, for the FC30 Pro, you do this by holding the power switch for 3 secs. The guide is here: [FC30 Pro Manual](http://download.8bitdo.com/Manual/FC30_Pro_Manual_ENG_v1.0.pdf)
+
+Type this at the command prompt
+`hcitool scan`
+This should find your controller and show its name and [MAC](https://en.wikipedia.org/wiki/MAC_address) address
+
+Pair the controller with this command, replace the XX data with your MAC address
+`sudo bluez-simple-agent -c DisplayYesNo hci0 XX:XX:XX:XX:XX:XX`
+
+Tell the system to trust your controller so you dont have to pair every time
+`sudo bluez-test-device trusted XX:XX:XX:XX:XX:XX yes`
+
+Then connect to your controller with
+`sudo bluez-test-input connect XX:XX:XX:XX:XX:XX`
+
+Your controller should then connect, with the 8bitdo controllers this is shown by a solid blue light that will begin to glow.
+
+### Step 3 - Making sure the connection attempt automatically starts when you reboot your Pi
+You may find the controller connects on startup without issue, but if not try this. There are different ways to do this, but this should work to start the connection attempt when the Pi starts up.
+Edit this startup file
+`sudo nano /etc/rc.local`
 
 above the line "exit 0" add
 
-`bluez-test-input connect XX:XX:XX:XX:XX:XX`  
-  
-Save the file with Ctrl-X and press Return to confirm the filename.  
+`bluez-test-input connect XX:XX:XX:XX:XX:XX`
 
-Now reboot the Pi.  
+Save the file with Ctrl-X and press Return to confirm the filename.
 
-### Step 4 - Configuring the controller using Emulation Station  
-Now the Pi is restarting, make sure your controller is turned on, and trying to pair (I tend to turn the controller on just before the RetroPie splashscreen appears), it should connect about when the Emulation Station splashscreen appears. Then Emulation Station will display with the "1 Gamepad Detected" message.  
+Now reboot the Pi.
 
-Hold a button down on the controller and follow the instructions to input your buttons.  
-When the is done, you click the "OK" button with the "A" button on the controller to enter Emulation Station.  
-This process will have configured your controller for navigating ES. It will also have created a controller file for RetroArch to use when you play games (If you are using at least RetroPie 3 beta 3).  
-  
-However, the content of that file may not have the correct buttons mappings (I'm not sure why this doesn't always work, as its fine with most other controllers). So we will update that file correctly now.  
-  
-### Step 5 - Updating the controller file for RetroArch  
-Press F4 to quit Emulation Station, and at the command prompt type  
-`cd /opt/retropie/configs/all/retroarch-joypads/`  
-`ls -lah`  
-    
-This should display the configuration file you created, delete it (although the next steps should overwrite this anyway) with:  
-`rm {filename} `  
-for example  
-`rm 8BitdoFC30Pro.cfg`  
-  
-Now we will recreate this using the retroarch controller script, type  
-`sudo /home/pi/RetroPie-Setup/retropie_setup.sh`  
- 
+### Step 4 - Configuring the controller using Emulation Station
+Now the Pi is restarting, make sure your controller is turned on, and trying to pair (I tend to turn the controller on just before the RetroPie splashscreen appears), it should connect about when the Emulation Station splashscreen appears. Then Emulation Station will display with the "1 Gamepad Detected" message.
+
+Hold a button down on the controller and follow the instructions to input your buttons.
+When the is done, you click the "OK" button with the "A" button on the controller to enter Emulation Station.
+This process will have configured your controller for navigating ES. It will also have created a controller file for RetroArch to use when you play games (If you are using at least RetroPie 3 beta 3).
+
+However, the content of that file may not have the correct buttons mappings (I'm not sure why this doesn't always work, as its fine with most other controllers). So we will update that file correctly now.
+
+### Step 5 - Updating the controller file for RetroArch
+Press F4 to quit Emulation Station, and at the command prompt type
+`cd /opt/retropie/configs/all/retroarch-joypads/`
+`ls -lah`
+
+This should display the configuration file you created, delete it (although the next steps should overwrite this anyway) with:
+`rm {filename} `
+for example
+`rm 8BitdoFC30Pro.cfg`
+
+Now we will recreate this using the retroarch controller script, type
+`sudo /home/pi/RetroPie-Setup/retropie_setup.sh`
+
 **--- This section is no longer accurate for Newer Releases of RetroPie- Please update these instructions. thanks----**
 
-Choose the "Setup" option, then "Configure input devices for RetroArch" (Do **not** choose the "Install RetroArch joypad autoconfigs)  
-Then choose the "Configure joystick/controller for use with RetroArch" option  
-Follow the on-screen prompts to press the buttons when prompted.  
-If you make a mistake, just run it again, it happily overwrites the file it needs to.  
+Choose the "Setup" option, then "Configure input devices for RetroArch" (Do **not** choose the "Install RetroArch joypad autoconfigs)
+Then choose the "Configure joystick/controller for use with RetroArch" option
+Follow the on-screen prompts to press the buttons when prompted.
+If you make a mistake, just run it again, it happily overwrites the file it needs to.
 
 -------------
-There should be no need to edit the retroarch.cfg to get your controller working.  
-  
-That should be all you need. Now when you start your Pi, set the controller to connect and it should be detected by Emulation Station and RetroArch based emulators.  
-  
-### Troubleshooting  
-If you have installed other bluetooth programs, perhaps to support a PS3 controller, you may find there are conflicts and the above steps produce an error when you try to pair. One way around this is to uninstall the sixad program with:  
+There should be no need to edit the retroarch.cfg to get your controller working.
+
+That should be all you need. Now when you start your Pi, set the controller to connect and it should be detected by Emulation Station and RetroArch based emulators.
+
+### Troubleshooting
+If you have installed other bluetooth programs, perhaps to support a PS3 controller, you may find there are conflicts and the above steps produce an error when you try to pair. One way around this is to uninstall the sixad program with:
 `sudo apt purge sixad`
-  
-If you are unsure your USB Bluetooth dongle is detected with the Pi, you can list the USB devices with:  
-`lsusb`  
-  
-The 8bitdo SFC30 controller appears to prefer to start with START + R (Right Shoulder) pressed to get into joystick mode.  
-  
-Sometimes there can be issues with the pairing process, to start that again you can remove the joypad like this   
+
+If you are unsure your USB Bluetooth dongle is detected with the Pi, you can list the USB devices with:
+`lsusb`
+
+The 8bitdo SFC30 controller appears to prefer to start with START + R (Right Shoulder) pressed to get into joystick mode.
+
+Sometimes there can be issues with the pairing process, to start that again you can remove the joypad like this
 `bluez-test-device remove XX:XX:XX:XX:XX:XX`
 
-**Keep bluetooth scanning**  
-This should keep the Pi scanning for bluetooth devices in case the pair is lost.  
-`sudo nano /etc/init.d/rc.local`  
-`add “sudo hciconfig hci0 up piscan” (without the quotes) above the line that says “exit 0”`  
-`ctrl x`  
-`y`  
-`enter`  
-`sudo reboot`  
+**Keep bluetooth scanning**
+This should keep the Pi scanning for bluetooth devices in case the pair is lost.
+`sudo nano /etc/init.d/rc.local`
+`add “sudo hciconfig hci0 up piscan” (without the quotes) above the line that says “exit 0”`
+`ctrl x`
+`y`
+`enter`
+`sudo reboot`
 
-**Some useful threads**  
-http://blog.petrockblock.com/forums/topic/8bitdo-bluetooth-controller-setup-retropie-v3/  
-http://blog.petrockblock.com/forums/topic/the-old-story-setting-up-2x-8bitdo-nes30-bluetooth/  
-http://forum.8bitdo.com/thread-328-1-1.html   
-https://wiki.archlinux.org/index.php/bluetooth#Bluetoothctl  
-https://wiki.archlinux.org/index.php/bluetooth_keyboard    
-http://8bitdo.com/Support.html  
-https://www.reddit.com/r/RetroPie/comments/4d5hcf/how_to_setup_8bitdo_nes30_fc30_pro_controllers_on/  
+**Some useful threads**
+http://blog.petrockblock.com/forums/topic/8bitdo-bluetooth-controller-setup-retropie-v3/
+http://blog.petrockblock.com/forums/topic/the-old-story-setting-up-2x-8bitdo-nes30-bluetooth/
+http://forum.8bitdo.com/thread-328-1-1.html
+https://wiki.archlinux.org/index.php/bluetooth#Bluetoothctl
+https://wiki.archlinux.org/index.php/bluetooth_keyboard
+http://8bitdo.com/Support.html
+https://www.reddit.com/r/RetroPie/comments/4d5hcf/how_to_setup_8bitdo_nes30_fc30_pro_controllers_on/
 https://github.com/libretro/retroarch-joypad-autoconfig/tree/master/udev
 https://retropie.org.uk/forum/topic/20303/rpi-3-b-tricky-bluetooth-problem-with-multiple-ps3-controllers/

--- a/docs/Configuration-Editor.md
+++ b/docs/Configuration-Editor.md
@@ -4,12 +4,11 @@ Manual configurations can also be set with the use of a keyboard.
 
 The Configuration Editor can be accessed from the RetroPie Menu or through the [RetroPie Setup Script](Updating-RetroPie) and navigate to **Setup ▶ Configuration / tools ▶ configedit **
 
-When changing settings, there are notes at the bottom of the screen that explain each setting and what they do. 
-  
-  
+When changing settings, there are notes at the bottom of the screen that explain each setting and what they do.
+
 ### Video Guide
 
-<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/rt2v-xCTDM0" title="RetroPie Configuration editor" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/rt2v-xCTDM0" title="RetroPie Configuration editor" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; allowfullscreen"></iframe>
 
 ### Basic Configuration
 

--- a/docs/Creating-Your-Own-EmulationStation-Theme.md
+++ b/docs/Creating-Your-Own-EmulationStation-Theme.md
@@ -114,8 +114,9 @@ However, this step is entirely optional. You can do all of this directly on the 
 
 **Set Up EmulationStation on PC**
 
+<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/oHtCnBiyzOY" title="EmulationStation Windows Portable (USB Stick)" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; allowfullscreen"></iframe>
+
 - Download the portable Emulationstation by @herb_fargus
-  - [Watch the video first](https://www.youtube.com/watch?v=oHtCnBiyzOY)
   - [Download the file](https://drive.google.com/file/d/0B2TMeZ6iEFvHYkNrMGVQSldkZ0U/view?usp=sharing)
 - Install/unzip it where you want it. I have it on F:/ Drive, so the path is F:\emulationstation
 - Download [this](https://dl.dropboxusercontent.com/u/14838442/fake-games.zip) zip file. Within it are 3 folders: 'gb', 'nes' and 'snes'. Within each folder are 15 blank .txt files, each named after a game on that system. These files have also had their extensions changed to something that ES will see as a rom.
@@ -164,8 +165,8 @@ Open `spare.xml` and add these lines:
 theme name:     Spare
 version:        1.0
 author:         Matt Kennedy
-email:          
-website:        
+email:
+website:
 license:        creative commons CC-BY-NC-SA
 based on:       "Carbon" by Eric Hettervik
 -->
@@ -173,7 +174,7 @@ based on:       "Carbon" by Eric Hettervik
 <theme>
 
     <formatVersion>4</formatVersion>
-    
+
     <view name="system"></view>
     <view name="basic"></view>
     <view name="detailed"></view>
@@ -184,7 +185,7 @@ based on:       "Carbon" by Eric Hettervik
 >When you are making your own theme you would obviously change the 'theme name' and 'author' fields to suit.
 
 - The theme details at the top just tell anyone looking who made the theme.
-- Anything within `<!-- x -->` is a comment, visible to humans who read the code, but invisible to Emulationstation. 
+- Anything within `<!-- x -->` is a comment, visible to humans who read the code, but invisible to Emulationstation.
 - The `<theme></theme>` fields tell Emulationstation that the code within is for a theme.
 - The `<formatVersion>4</formatVersion>` sets the theme version. I don't really know much about this, just that most themes use version 3, but if you want to allow for the Child-Friendly version of ES, you need to use version 4.
 - `<view name="x"></view>` governs what happens in each of those views.
@@ -199,12 +200,12 @@ Open `spare/gb/theme.xml` and add these lines:
 
     <formatVersion>4</formatVersion>
     <include>./../spare.xml</include>
-    
+
     <view name="system"></view>
     <view name="basic"></view>
     <view name="detailed"></view>
     <view name="video"></view>
-    
+
 </theme>
 ```
 Notice it's almost identical to `spare.xml`, except for a few things. You don't need to specify any theme details, because we are using this line:
@@ -495,8 +496,8 @@ Open `spare.xml`. It should look like this:
 theme name:     Spare
 version:        1.0
 author:         Matt Kennedy
-email:          
-website:        
+email:
+website:
 license:        creative commons CC-BY-NC-SA
 based on:       "Carbon" by Eric Hettervik
 -->
@@ -504,7 +505,7 @@ based on:       "Carbon" by Eric Hettervik
 <theme>
 
     <formatVersion>4</formatVersion>
-    
+
     <view name="system">
 		<image name="background_color" extra="true">
 			<path>./_inc/images/bg_color.png</path>
@@ -692,7 +693,7 @@ However, it starts off looking like this:
 
 Open `spare.xml`.
 
-We're going to start by placing a bunch of Helper boxes to block out where we want everything. 
+We're going to start by placing a bunch of Helper boxes to block out where we want everything.
 
 - You can use an image editing program to mock this up beforehand, and this is where the ES Theme Helper comes in very handy.
 - Or you can just sort of freehand it. Add a box, check its shape, move it, resize it, check it again. Keep doing that until you are happy with it, and then add another box (this was the way I made this theme).
@@ -1173,8 +1174,8 @@ This is my complete `spare.xml`:
 theme name:		Spare
 version:		1.0
 author:			Matt Kennedy
-email:			
-website:		
+email:
+website:
 license:		creative commons CC-BY-NC-SA
 based on:		"Carbon" by Eric Hettervik
 -->
@@ -1257,7 +1258,7 @@ based on:		"Carbon" by Eric Hettervik
 	</view>
 
 	<view name="detailed">
-		
+
 		<image name="background_logo_gamelist" extra="true">
 			<path>./_inc/images/bg_color.png</path>
 			<origin>0 0</origin>
@@ -1283,7 +1284,7 @@ based on:		"Carbon" by Eric Hettervik
 				<fontSize>0.04</fontSize>
 				<horizontalMargin>0.01</horizontalMargin>
 			</textlist>
-		
+
 		<image name="background_image" extra="true">
 			<path>./_inc/images/bg_color.png</path>
 			<origin>0 0</origin>
@@ -1297,7 +1298,7 @@ based on:		"Carbon" by Eric Hettervik
 				<pos>0.545 0.33</pos>
 				<maxSize>0.33 0.58</maxSize>
 			</image>
-		
+
 		<image name="background_metadata" extra="true">
 			<path>./_inc/images/bg_color.png</path>
 			<origin>0 0</origin>
@@ -1387,7 +1388,7 @@ based on:		"Carbon" by Eric Hettervik
 				<datetime name="md_lastplayed">
 					<pos>0.75 0.50</pos>
 				</datetime>
-		
+
 		<image name="background_description" extra="true">
 			<path>./_inc/images/bg_color.png</path>
 			<origin>0 0</origin>
@@ -1415,10 +1416,10 @@ based on:		"Carbon" by Eric Hettervik
 And my complete `theme.xml`, which is identical in each system folder:
 ```
 <theme>
-	
+
 	<formatVersion>4</formatVersion>
 	<include>./../spare.xml</include>
-	
+
 	<view name="system, basic, detailed">
 
 		<image name="logo">
@@ -1426,7 +1427,7 @@ And my complete `theme.xml`, which is identical in each system folder:
 		</image>
 
 	</view>
-	
+
 </theme>
 ```
 
@@ -1445,7 +1446,7 @@ Congratulations to those that made it this far. It's been a heck of a journey. Y
 - Fake "games" zip file from my DropBox
   - [fake_games.zip](https://dl.dropboxusercontent.com/u/14838442/fake-games.zip)
 - Portable Emulationstation by @herb_fargus:
-  - [Watch the video first](https://www.youtube.com/watch?v=oHtCnBiyzOY)
+  - [EmulationStation Windows Portable (USB Stick)](https://www.youtube.com/watch?v=oHtCnBiyzOY)
   - [Download the file](https://drive.google.com/file/d/0B2TMeZ6iEFvHYkNrMGVQSldkZ0U/view?usp=sharing)
 - The ES Theme Helper by @Rookervik:
   -  [Get it from @Rookervik's DropBox here](https://dl.dropboxusercontent.com/u/60872572/EmulationStation/ES%20Theme%20Helper3.rar)
@@ -1455,3 +1456,6 @@ Congratulations to those that made it this far. It's been a heck of a journey. Y
   - [Imgur](http://imgur.com/a/LjRZk)
 - My other theme:
   - [MetaPixel](https://github.com/mattrixk/es-theme-metapixel)
+- A generic tutorial on how to convert a rasterimage to vector image:
+
+<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/q9Fk6OzX86U" title="Tutorial on creating Vector (SVG) logos from Bitmaps (e.g. PNG)" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; allowfullscreen"></iframe>

--- a/docs/Dreamcast.md
+++ b/docs/Dreamcast.md
@@ -13,9 +13,9 @@ _The Sega Dreamcast is a 6th generation home video game console released by Sega
 
 ## Emulators: [Reicast](https://github.com/reicast/reicast-emulator), [lr-flycast](https://github.com/libretro/flycast.git), [Redream](https://redream.io)
 
-Reicast can be very laggy and buggy, but some games work great. Pi 2 or later is required. 
+Reicast can be very laggy and buggy, but some games work great. Pi 2 or later is required.
 
-Audio is choppy and not great, and degrades the longer the emulator is in use.  Restarting the emulator (and ultimately the Pi) may become a good idea after a couple hours of gameplay. There is a memory leak somewhere in the Reicast code. Low screen resolution are recommended to get best performance. Performance greatly suffers if HD resolutions are used.   
+Audio is choppy and not great, and degrades the longer the emulator is in use.  Restarting the emulator (and ultimately the Pi) may become a good idea after a couple hours of gameplay. There is a memory leak somewhere in the Reicast code. Low screen resolution are recommended to get best performance. Performance greatly suffers if HD resolutions are used.
 
 lr-flycast can be found in the _Optional_ packages section in the RetroPie Setup Script and on a Pi4 it has much better performance than Reicast.
 
@@ -45,28 +45,27 @@ Place your BIOS files in
 
 BIOS files
 
-| File | Region | md5sum | CRC32 | Comment |
-| :--: | :--: | :--: | :--: | :--: |
-| dc_boot.bin | World | e10c53c2f8b90bab96ead2d368858623 | 89f2b1a1 | |
-| dc_flash.bin | USA | 0a93f7940c455905bea6e392dfde92a4 | c611b498 | |
-| dc_flash.bin | Europe | 23df18aa53c8b30784cd9a84e061d008 | b7e5aeeb | |
-| dc_flash.bin | Japan | 69c036adfca4ebea0b0c6fa4acfc8538 | 5f92bf76 | |
-| dc_boot.bin | Free | d407fcf70b56acb84b8c77c93b0e5327 | 61d5613f | Hack |
-| dc_flash.bin | Free | 93a9766f14159b403178ac77417c6b68 | e0d202a2 | Hack |
-| dc_boot.bin | Free | d552d8b577faa079e580659cd3517f86 | 558f456e | atreyu187 Hack |
-| dc_flash.bin | Free | 74e3f69c2bb92bc1fc5d9a53dcf6ffe2 | bda0e9aa | atreyu187 Hack |
-| naomi.zip | World | eb4099aeb42ef089cfe94f8fe95e51f6 | c295a8c2 | NAOMI BIOS |
-| awbios.zip | World | 0ec5ae5b5a5c4959fa8b43fcf8687f7c | ab628024 | Atomiswave BIOS |
+|     File     | Region |              md5sum              |  CRC32   |     Comment     |
+| :----------: | :----: | :------------------------------: | :------: | :-------------: |
+| dc_boot.bin  | World  | e10c53c2f8b90bab96ead2d368858623 | 89f2b1a1 |                 |
+| dc_flash.bin |  USA   | 0a93f7940c455905bea6e392dfde92a4 | c611b498 |                 |
+| dc_flash.bin | Europe | 23df18aa53c8b30784cd9a84e061d008 | b7e5aeeb |                 |
+| dc_flash.bin | Japan  | 69c036adfca4ebea0b0c6fa4acfc8538 | 5f92bf76 |                 |
+| dc_boot.bin  |  Free  | d407fcf70b56acb84b8c77c93b0e5327 | 61d5613f |      Hack       |
+| dc_flash.bin |  Free  | 93a9766f14159b403178ac77417c6b68 | e0d202a2 |      Hack       |
+| dc_boot.bin  |  Free  | d552d8b577faa079e580659cd3517f86 | 558f456e | atreyu187 Hack  |
+| dc_flash.bin |  Free  | 74e3f69c2bb92bc1fc5d9a53dcf6ffe2 | bda0e9aa | atreyu187 Hack  |
+|  naomi.zip   | World  | eb4099aeb42ef089cfe94f8fe95e51f6 | c295a8c2 |   NAOMI BIOS    |
+|  awbios.zip  | World  | 0ec5ae5b5a5c4959fa8b43fcf8687f7c | ab628024 | Atomiswave BIOS |
+
 
 **Note:** If you are having trouble with having to set the date/time every time you load Reicast, [see this forum post](https://retropie.org.uk/forum/post/53941) for a guide on how to replace dc_flash.bin. The MD5 of the dc_flash.bin generated from that guide should be `2f818338f47701c606ade664a3e16a8a`.
 
 **Note:** As of February 2019, the date/time prompt should appear only the 1st time Reicast is started.
 
-## Video Setup Guide  
+## Video Setup Guide
 
-<a href="https://www.youtube.com/watch?v=yAB0_kkaa5s
-" target="_blank"><img src="https://i.ytimg.com/vi_webp/yAB0_kkaa5s/mqdefault.webp" 
-alt="RetroPie Dreamcast emulation" width="300" height="190" border="10" /></a>  
+<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/yAB0_kkaa5s" title="RetroPie: Sega Dreamcast Emulation on Raspberry Pi" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; allowfullscreen"></iframe>
 
 RetroPie 4.0 uses an output resolution independent render resolution of 640x480. Open `/home/pi/.reicast/emu.cfg` to modify render resolution.
 
@@ -75,16 +74,17 @@ RetroPie 4.0 uses an output resolution independent render resolution of 640x480.
 ```
 /opt/retropie/configs/all/autoconf.cfg
 ```
-Option | Description | Value
---- | --- | ---
-reicast_input | enable input auto configuration | (0/1)
+
+| Option        | Description                     | Value |
+| ------------- | ------------------------------- | ----- |
+| reicast_input | enable input auto configuration | (0/1) |
 
 ## VMUs
 
 ### Reicast
-VMUs are stored as .BIN files under `/home/pi/.reicast/`, and will be automatically created the first time you run Reicast without VMU files.  
+VMUs are stored as .BIN files under `/home/pi/.reicast/`, and will be automatically created the first time you run Reicast without VMU files.
 
-On occasion, these VMUs do not get formatted quite right during creation, and the Dreamcast can't save or load data from them.  They just need to be reformatted -- run the `SYSTEMMANAGER` entry in the EmulationStation Dreamcast menu and / or see [this post](http://blog.petrockblock.com/forums/topic/configuring-controllers-in-reicast/page/2/#post-99715) for details. 
+On occasion, these VMUs do not get formatted quite right during creation, and the Dreamcast can't save or load data from them.  They just need to be reformatted -- run the `SYSTEMMANAGER` entry in the EmulationStation Dreamcast menu and / or see [this post](http://blog.petrockblock.com/forums/topic/configuring-controllers-in-reicast/page/2/#post-99715) for details.
 
 ### lr-flycast
 VMUs are stored as .BIN files under `/home/pi/RetroPie/BIOS/dc/`, and will be automatically created the first time you run lr-flycast.
@@ -134,7 +134,7 @@ In more recent builds of reicast, the +Start Reicast script launches a landing p
 
 In stock configuration, access to this menu is controlled from the D-Pad of a controller with an analog stick. In the case where your controller does not have an analog stick, it may be necessary to connect one in order to access this part of the menu and create mappings for your other controllers.
 
-Some example mappings are provided below for various controllers which can be directly edited from the 
+Some example mappings are provided below for various controllers which can be directly edited from the
 ```
 /opt/retropie/configs/dreamcast/mappings/
 ```
@@ -166,17 +166,17 @@ button.16=Quit
 axis.0=Axis_X
 axis.1=Axis_Y
 ```
-If mapping is not working correctly try changing controller name for: 
+If mapping is not working correctly try changing controller name for:
 ```
 [Sony PLAYSTATION(R)3 Controller]
 ```
-For Wireless PS3 Controller use: 
+For Wireless PS3 Controller use:
 ```
 [PLAYSTATION(R)3 Controller (xx:xx:xx:xx:xx:xx)]
 ```
 Replace xx:xx:xx:xx:xx:xx with your own controller mac address
 
-Press ctrl+c to exit- Or map a Quit button (PS) as shown above :D 
+Press ctrl+c to exit- Or map a Quit button (PS) as shown above :D
 
 
 **Xbox 360 Controller:**
@@ -189,7 +189,7 @@ btn_escape = 0x13a
 [dreamcast]
 btn_a = 0x130h
 btn_b = 0x131h
-btn_c = 
+btn_c =
 btn_d = 0x139h
 btn_x = 0x133h
 btn_y = 0x134h
@@ -351,12 +351,12 @@ axis_dpad1_y_inverted = no
 axis_dpad1_x_inverted = no
 ```
 
-**iBuffalo Classic USB GamePad [EXPERIMENTAL]** 
+**iBuffalo Classic USB GamePad [EXPERIMENTAL]**
 
 Analog movement not supported
 ```
 [emulator]
-mapping_name = USB,2-axis 8-button gamepad  
+mapping_name = USB,2-axis 8-button gamepad
 btn_escape = 294
 
 [dreamcast]

--- a/docs/First-Installation.md
+++ b/docs/First-Installation.md
@@ -3,16 +3,15 @@
 |Version|4.8|
 |:---:|:---:|
 
-Congratulations! You have discovered the wonderful world of RetroPie- your entire childhood is within reach! RetroPie is a combination of multiple projects including [RetroArch](http://www.retroarch.com), [EmulationStation](https://www.emulationstation.org), and many others. 
+Congratulations! You have discovered the wonderful world of RetroPie- your entire childhood is within reach! RetroPie is a combination of multiple projects including [RetroArch](http://www.retroarch.com), [EmulationStation](https://www.emulationstation.org), and many others.
 
-This page is for people just getting started on RetroPie. The easiest way to install RetroPie is the SD image which is a ready to go system built upon top of the Raspberry Pi OS - this is the method described in the following guide. Alternatively, advanced users can install RetroPie [manually](Manual-Installation). 
+This page is for people just getting started on RetroPie. The easiest way to install RetroPie is the SD image which is a ready to go system built upon top of the Raspberry Pi OS - this is the method described in the following guide. Alternatively, advanced users can install RetroPie [manually](Manual-Installation).
 
 This guide will give you the very basics to get you up and running from a blank MicroSD card to first boot into EmulationStation.
 
-The following video will also walk you through the installation process. Otherwise read on! 
+The following video will also walk you through the installation process. Otherwise read on!
 
-<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/E1sbnPZ_A8w" title="RetroPie First Installation Video" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-
+<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/E1sbnPZ_A8w" title="RetroPie First Installation Video" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; allowfullscreen"></iframe>
 
 ## Hardware
 
@@ -34,7 +33,7 @@ The simplest way to get most of these components is through an all-in-one kit su
   * [4-Pole RCA to 3.5mm](https://user-images.githubusercontent.com/540857/107688722-f3ab5f00-6c75-11eb-9837-ffe7f385b1c5.jpg) is also an option for older screens
 * Power supply
   * View the official [Raspberry Pi Power](https://www.raspberrypi.org/documentation/computers/raspberry-pi.html#power-supply) documentation for each model
-* Game controller of your choice 
+* Game controller of your choice
   * Can be USB-wired, wireless (with a dongle), or Bluetooth (with or without a dongle. Pi 3 and later models have built-in Bluetooth and won't need a dongle)
   * The [Control Block](http://blog.petrockblock.com/2014/12/29/controlblock-power-switch-and-io-for-the-raspberry-pi/) can use original SNES controllers
 
@@ -74,7 +73,7 @@ Follow the onscreen instructions to configure your gamepad. If your controller d
 
 See the following diagrams for reference:
 
-| SNES Controller | 
+| SNES Controller |
 |:---:|
 |![snes_controller](https://cloud.githubusercontent.com/assets/10035308/22185414/f129dc28-e099-11e6-8524-93facf275eda.png)|
 
@@ -113,7 +112,7 @@ For more information, see [Hotkeys](RetroArch-Configuration#hotkeys)
 ## EmulationStation
 
 | **Where are the systems?**|
-| :---: | 
+| :---: |
 **When you first see EmulationStation you may wonder why you don't see systems like the SNES or Game Boy. Worry not - the emulators are installed on the system, but ROMs will need to be added to their respective rom folders before they will become visible**|
 |![firstboot](https://cloud.githubusercontent.com/assets/10035308/16217874/c6bbdb3a-3734-11e6-998f-8cc714a320ce.png)|
 
@@ -134,10 +133,10 @@ After you've transferred your ROMs, you need to restart EmulationStation in orde
 * [Configure Wifi](Wifi)
 * [Enable SSH](SSH)
 * Configure more controllers. This can be done after plugging in the new controller and pressing *Start* on your controller and selecting *Configure Input*
-* In RetroPie, not everything is installed by default. The pre-made images contain the best-working emulators for the more common systems supported by the hardware. This should cover typical use, but if you want to install additional emulators or ports, the [Updating RetroPie](https://retropie.org.uk/docs/Updating-RetroPie/#updatinginstalling-individual-packages) page has this information. 
+* In RetroPie, not everything is installed by default. The pre-made images contain the best-working emulators for the more common systems supported by the hardware. This should cover typical use, but if you want to install additional emulators or ports, the [Updating RetroPie](https://retropie.org.uk/docs/Updating-RetroPie/#updatinginstalling-individual-packages) page has this information.
 * [Cheat codes](Cheats)!
 
-See the rest of the [RetroPie documentation](https://retropie.org.uk/docs/) for more detailed information on individual emulators, advanced settings, etc. If you're having trouble, you may find answers in the [FAQ](FAQ). Also, the RetroPie community is very helpful on the [RetroPie forum](https://retropie.org.uk/forum/). 
+See the rest of the [RetroPie documentation](https://retropie.org.uk/docs/) for more detailed information on individual emulators, advanced settings, etc. If you're having trouble, you may find answers in the [FAQ](FAQ). Also, the RetroPie community is very helpful on the [RetroPie forum](https://retropie.org.uk/forum/).
 
 **The RetroPie Project is primarily maintained by a few developers who develop the project in their free time. If you have found the RetroPie project useful please consider donating to the project [here](https://retropie.org.uk/donate/). As you become more familiar with RetroPie, pay it forward by helping others on the forum. The RetroPie Project is what it is today because of the many contributions of the community.**
 

--- a/docs/Game-&-Watch.md
+++ b/docs/Game-&-Watch.md
@@ -25,10 +25,9 @@ Place your Game & Watch ROMs in
 
 Games can be found at the [Libretro Handheld Electronic Games page](https://bot.libretro.com/assets/cores/Handheld%20Electronic%20Game/).
 
-### Video Guide  
+### Video Guide
 
-<a href="https://www.youtube.com/watch?v=DzbsfCC77IQ" target="_blank"><img src="https://i.ytimg.com/vi_webp/DzbsfCC77IQ/mqdefault.webp" 
-alt="RetroPie Game and Watch emulation" width="300" height="190" border="10" /></a>  
+<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/DzbsfCC77IQ" title="RetroPie: Game and Watch emulation on a Raspberry Pi" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; allowfullscreen"></iframe>
 
 ## Controls
 

--- a/docs/Game-Boy-Advance.md
+++ b/docs/Game-Boy-Advance.md
@@ -27,7 +27,7 @@ Sadly, netplay is not supported on link cable games.
 ## ROMS
 Accepted File Extensions: **.7z .gba .zip**
 
-Place your Game Boy Advance ROMS in 
+Place your Game Boy Advance ROMS in
 ```
 /home/pi/RetroPie/roms/gba
 ```
@@ -107,5 +107,4 @@ Select: Backspace
 ```
 ## Video Tutorial:
 
-<a href="https://www.youtube.com/watch?v=eM9BB9v9288" target="_blank"><img src="https://i.ytimg.com/vi_webp/eM9BB9v9288/mqdefault.webp" 
-alt="GBA Configuration Video" width="300" height="180" border="10" /></a>
+<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/eM9BB9v9288" title="Setting Up RetroPie 2 6: How to Configure Gameboy Advance (GPSP, Libretro-VBA-next)" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; allowfullscreen"></iframe>

--- a/docs/GemRB.md
+++ b/docs/GemRB.md
@@ -9,12 +9,7 @@ _GemRB is a portable open-source implementation of Bioware's Infinity Engine. It
 
 ## Emulator [GemRB](https://github.com/gemrb/gemrb)
 
-<a href="https://www.youtube.com/watch?v=W3YsyRDc_Os
-" target="_blank"><img src="https://i.ytimg.com/vi_webp/W3YsyRDc_Os/mqdefault.webp" 
-alt="RetroPie with Bluetooth" width="300" height="190" border="10" /></a>  
-  
-**Video Guide**: https://www.youtube.com/watch?v=W3YsyRDc_Os  
-
+<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/W3YsyRDc_Os" title="RetroPie - Baldurs Gate running on a Raspberry Pi with GemRB" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; allowfullscreen"></iframe>
 
 ## Roms
 

--- a/docs/Nintendo-64.md
+++ b/docs/Nintendo-64.md
@@ -25,7 +25,7 @@ Accepted File Extensions: **.z64 .n64 .v64 .zip**
 
 **Note:** **Mupen64Plus** standalone cannot directly load compressed zip files.
 
-Place your Nintendo 64 ROMs in 
+Place your Nintendo 64 ROMs in
 ```
 /home/pi/RetroPie/roms/n64
 ```
@@ -56,8 +56,8 @@ Option | Description | Value
 `[Audio-OMX]` `OUTPUT_PORT` | Audio output path is Jack or HDMI. (will be overwritten if `mupen64plus_audio` is enabled) | (0=Audio Jack / **1=HDMI**)
 `[CoreEvents]` `Joy Mapping Stop` | Joystick exit button. (will be overwritten if `mupen64plus_hotkeys` is enabled) | J**X**B**Y**/B**Z** or J**X**B**Y**
 `[CoreEvents]` `Joy Mapping Load State` | Joystick load state button. (will be overwritten if `mupen64plus_hotkeys` is enabled) | J**X**B**Y**/B**Z** or J**X**B**Y**
-`[CoreEvents]` `Joy Mapping Save State` | Joystick save state button. (will be overwritten if `mupen64plus_hotkeys` is enabled) | J**X**B**Y**/B**Z** or J**X**B**Y** 
-`[Video-GLideN64]` `EnableFBEmulation` | Enable framebuffer emulation. Games like Mario Tennis need this option to render framebuffer effects. Some games have glitches if this option is enabled. (will be overwritten if `compatibility_check` is enabled) | (True/**False**) 
+`[CoreEvents]` `Joy Mapping Save State` | Joystick save state button. (will be overwritten if `mupen64plus_hotkeys` is enabled) | J**X**B**Y**/B**Z** or J**X**B**Y**
+`[Video-GLideN64]` `EnableFBEmulation` | Enable framebuffer emulation. Games like Mario Tennis need this option to render framebuffer effects. Some games have glitches if this option is enabled. (will be overwritten if `compatibility_check` is enabled) | (True/**False**)
 `[Video-GLideN64]` `EnableLegacyBlending` | Use fixed-function pipeline instead of shaders for blending for speed. Some games have glitches if this option is enabled. (will be overwritten if `compatibility_check` is enabled) | (True/**False**)  | (**True**/False)
 
 #### Scaling Mode
@@ -117,21 +117,18 @@ Y Axis = "hat(0 Up Down)"
 
 #### Hotkey combinations and special buttons
 
-Key | Description
---- | ---
-Hotkey + Start | Exit emulator.
-Hotkey + Left Shoulder | Load state.
-Hotkey + Right Shoulder | Save state.
-Left Thumb | Enable memory expansion pak.
-Right Thumb | Enable rumble expansion pak.
+| Key                     | Description                  |
+| ----------------------- | ---------------------------- |
+| Hotkey + Start          | Exit emulator.               |
+| Hotkey + Left Shoulder  | Load state.                  |
+| Hotkey + Right Shoulder | Save state.                  |
+| Left Thumb              | Enable memory expansion pak. |
+| Right Thumb             | Enable rumble expansion pak. |
 
 **Note:** Hotkey and other buttons refers to those bound during [Controller Configuration](Controller-Configuration).
 
 ## Video Tutorials
 
-<a href="http://www.youtube.com/watch?feature=player_embedded&v=4WX7RrzUtII
-" target="_blank"><img src="https://i.ytimg.com/vi_webp/4WX7RrzUtII/mqdefault.webp" 
-alt="N64 Configuration Video" width="300" height="180" border="10" /></a> |
-<a href="https://www.youtube.com/watch?v=lh0n5PWN2lI
-" target="_blank"><img src="https://i.ytimg.com/vi_webp/lh0n5PWN2lI/mqdefault.webp" 
-alt="N64 Configuration Video" width="300" height="180" border="10" /></a> 
+<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/4WX7RrzUtII" title="RetroPie: How to get N64 Emulation working on the Raspberry Pi" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; allowfullscreen"></iframe>
+
+<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/lh0n5PWN2lI" title="RetroPie N64 Tutorial - Nintendo 64 Emulation Setup and Config" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; allowfullscreen"></iframe>

--- a/docs/Optimization-for-Nintendo-64.md
+++ b/docs/Optimization-for-Nintendo-64.md
@@ -2,9 +2,9 @@
 
 N64 emulation on the raspberry pi is difficult due to the pi's under powered GPU (Graphics Processing Unit) and lack of certain GPU features found in more modern devices.
 
-If you are looking for a more perfect N64 emulation experience you should seriously consider different hardware first (i.e. a desktop computer, modern mobile phone/tablet etc.). However, listed below are several tweaks that can be made to your raspberry pi that will help maximize N64 performance and make many of the popular N64 titles playable. 
+If you are looking for a more perfect N64 emulation experience you should seriously consider different hardware first (i.e. a desktop computer, modern mobile phone/tablet etc.). However, listed below are several tweaks that can be made to your raspberry pi that will help maximize N64 performance and make many of the popular N64 titles playable.
 
-## Hardware and Configuration 
+## Hardware and Configuration
 
 A Raspberry Pi 3 or later model is highly suggested to maximize performance.
 
@@ -16,9 +16,9 @@ A Raspberry Pi 3 or later model is highly suggested to maximize performance.
 
 Overclocking is setting a hardware component to run faster than originally intended by the manufacturer. It can add instability if not done properly. It will also make your pi run hotter. There are no standard settings for overclocking and not all pis will handle the same amount of overclocking. Therefore before you begin overclocking please review [this article](Overclocking) first for proper overclocking methods and stability testing to prevent SD card corruption and potential loss of your data.
 
-For boosting N64 performance, it is the```core_freq```(GPU core) setting that will give the most benefit. Most pis I tested were stable between ```core_freq=500``` and ```core_freq=575``` with some amount of ```over_voltage``` applied. Again, it is important to remember that not all pis are equal, some will only overclock a little or not at all. You will need to experiment to see how much your pi can handle. If your pi freezes or crashes then your overclock is unstable. 
+For boosting N64 performance, it is the```core_freq```(GPU core) setting that will give the most benefit. Most pis I tested were stable between ```core_freq=500``` and ```core_freq=575``` with some amount of ```over_voltage``` applied. Again, it is important to remember that not all pis are equal, some will only overclock a little or not at all. You will need to experiment to see how much your pi can handle. If your pi freezes or crashes then your overclock is unstable.
 
-Overclocking ```sdram_freq``` will give a very small boost to performance. Going from 450mhz to 550mhz yielded at best about a 1FPS increase. Sdram has its own over voltage value ```over_voltage_sdram```. 
+Overclocking ```sdram_freq``` will give a very small boost to performance. Going from 450mhz to 550mhz yielded at best about a 1FPS increase. Sdram has its own over voltage value ```over_voltage_sdram```.
 
 ```v3d_freq```can also be overclocked. This helped improve performance for a couple games I tested. Most of the raspberry pis I tested were stable to at least ```v3d_freq=500``` but not much past this.
 
@@ -31,9 +31,9 @@ then cancel, exit and reboot.
 
 ## Selecting the Correct Emulator and Graphics Plugin
 
-Just as important as overclocking, selecting the right emulator/graphics plugin from the [runcommand](Runcommand#runcommand-launch-menu) menu on a per game basis will also increase performance. Selecting the right plugin can make all the difference in making a game playable. 
+Just as important as overclocking, selecting the right emulator/graphics plugin from the [runcommand](Runcommand#runcommand-launch-menu) menu on a per game basis will also increase performance. Selecting the right plugin can make all the difference in making a game playable.
 
-The current default emulator is mupen64plus-auto which will attempt to select the correct graphics plugin for you, however for best results it is best to test each plugin for yourself on a per game basis. It is recommended that you confirm a game runs well with the standard low-res plugin before attempting to use the hi-res option. 
+The current default emulator is mupen64plus-auto which will attempt to select the correct graphics plugin for you, however for best results it is best to test each plugin for yourself on a per game basis. It is recommended that you confirm a game runs well with the standard low-res plugin before attempting to use the hi-res option.
 
 Each N64 emulator/video plugin should be set to the lowest resolution (CEA-1 for most displays) through the runcommand menu. This will slightly increase performance by limiting the up-scaling the pi has to perform. This is not necessary for the gles2n64 video plugin.
 
@@ -42,10 +42,10 @@ Each N64 emulator/video plugin should be set to the lowest resolution (CEA-1 for
 
 
 ## High Resolution Texture Packs
-Instructional Video https://www.youtube.com/watch?v=b3p9pYvDT-Y 
 
+<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/b3p9pYvDT-Y" title="N64 Retropie High Resolution Texture Pack How To" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; allowfullscreen"></iframe>
 
-From Current version forward High Resolution Texture options are automatically configured to `True` in the configuration files for Rice and Glide.  You should not need to modify them as you did with previous versions.  Some libretro emulators support loading Hi-Rez textures and you can look for enabling those options in the libretro xmb.  
+From Current version forward High Resolution Texture options are automatically configured to `True` in the configuration files for Rice and Glide.  You should not need to modify them as you did with previous versions.  Some libretro emulators support loading Hi-Rez textures and you can look for enabling those options in the libretro xmb.
 
 
 You need to place high res texture packs in the directory `/home/pi/.local/share/mupen64plus/hires_texture`
@@ -61,7 +61,7 @@ sudo unzip texturepack.zip
 
 Texture packs are available for download [here](http://textures.emulation64.com/index.php?id=downloads).
 
-The folder name in that directory must match the core name in the rom header or the texture pack will not be properly applied.Most cases the default directory name is ok but you may need to check if you find if your rom is not correctly launching the texture pack. 
+The folder name in that directory must match the core name in the rom header or the texture pack will not be properly applied.Most cases the default directory name is ok but you may need to check if you find if your rom is not correctly launching the texture pack.
 
 Here is a list of the proper format of names for the top level folder on texture packs that have been tested:
 - F-ZERO X
@@ -75,22 +75,22 @@ Here is a list of the proper format of names for the top level folder on texture
 - ZELDA MAJORA'S MASK
 
 
-To confirm the correct name for a texture pack you may not be able to get to load  you can use the command to display the core name just use the command below in terminal then exit and scroll up I do it from a remote ssh session like putty cause you can scroll up and read it.  In the first few lines it will show the core name 
+To confirm the correct name for a texture pack you may not be able to get to load  you can use the command to display the core name just use the command below in terminal then exit and scroll up I do it from a remote ssh session like putty cause you can scroll up and read it.  In the first few lines it will show the core name
 ```
 cd /home/pi/RetroPie/roms/n64
 /opt/retropie/emulators/mupen64plus/bin/mupen64plus.sh mupen64plus-video-rice rom name
 ```
 
-You can use the same command to launch the rom correctly loading the texture pack. 
+You can use the same command to launch the rom correctly loading the texture pack.
 
-Two things you need to do once you have texture packs placed in the proper directory and named correctly. 
+Two things you need to do once you have texture packs placed in the proper directory and named correctly.
 
 You need to make sure you are launching that rom specifically with either Glide or Rice (maybe libretro if you have enabled libretro specifically to load hi rez textures)
 and
 You need to make sure you are using a resolution at 800x600 or higher in order for the texture pack to load.  You should use the highest resolution setting you can get the game performing well on it will look better the higher the resolution.
 
 
-Please also feel free to reference the Rice 64 github page for the source documentation 
+Please also feel free to reference the Rice 64 github page for the source documentation
 https://github.com/mupen64plus/mupen64plus-video-rice
 
 

--- a/docs/Overclocking.md
+++ b/docs/Overclocking.md
@@ -160,15 +160,15 @@ All Raspberry Pi models can be manually overclocked by editing `/boot/config.txt
 
 Parameters are set like:
 
-~~~
+```
 parameter=value
-~~~
+```
 
 For example, to set the ARM to 1000MHz:
 
-~~~
+```
 arm_freq=1000
-~~~
+```
 
 #### Useful Parameters
 
@@ -220,23 +220,23 @@ Setting `force_turbo=1` results in all components running at their maximum speed
 
 The default settings for each model Pi are:
 
-~~~
+```
         ARM   Core    GPU   RAM
 Pi 1    700    250    250   400
 Pi 2    900    250    250   400
 Pi 3   1200    400    300   450
-Pi 3B+ 1400    400    300   500  
+Pi 3B+ 1400    400    300   500
 Zero   1000    400    300   450
-~~~
+```
 
 #### Where Do I Start?
 
 Where emulation benefits from overclocks, there are two types:
 
-* *Emulation restricted by the CPU*  
+* *Emulation restricted by the CPU*
     such as MAME which has no 3D acceleration at all (neither on the Pi or on any other computer)
 
-* *Emulation restricted by the GPU*  
+* *Emulation restricted by the GPU*
     such as N64 which is based around graphics plugins and is relying mostly on the OpenGL V3D core to do work for it
 
 You can measure CPU usage with `top` or `htop`. If emulation runs poorly and CPU usage is at maximum, emulation is probably limited by the CPU. If emulation runs poorly and CPU usage is *not* at 100%, emulation is probably limited by the GPU.
@@ -249,16 +249,16 @@ Some rules of thumb to start Raspberry Pi overclocking:
 
 If overclocking the CPU (`arm_freq`), start at the original speed and take it up in steps of 50MHz.
 
-If overclocking the GPU (`core_freq` or `gpu_freq`), start at `500` (or `400` for Pi 1)  and take them up in steps of 20MHz or 25MHz. Remember gpu_freq will overclock all of the GPU (including core_freq) and core_freq will over clock just the GPU processor itself. This also influences the L2 cache of the CPU which has very minor performance increase [mostly seen on the Pi Zero]https://www.raspberrypi.org/documentation/computers/config_txt.html#overclocking-options).
+If overclocking the GPU (`core_freq` or `gpu_freq`), start at `500` (or `400` for Pi 1)  and take them up in steps of 20MHz or 25MHz. Remember gpu_freq will overclock all of the GPU (including core_freq) and core_freq will over clock just the GPU processor itself. This also influences the L2 cache of the CPU which has very minor performance increase [mostly seen on the Pi Zero](https://www.raspberrypi.org/documentation/computers/config_txt.html#overclocking-options).
 
 For voltage, you are probably best to start with `over_voltage=2` then increase by `1` if the system becomes unstable.
 
 For RAM, start with the original speed and again go up in small steps of 20MHz or 25MHz, increasing voltage in steps of `1` if things become unstable. The `schmoo` setting is some timings known to help increase stability of overclocked RAM:
 
-~~~
+```
 sdram_schmoo=0x02000020
 over_voltage_sdram=2
-~~~
+```
 
 After many config file edits and reboots it's difficult to remember exactly which settings were best and which didn't have any effect and which broke things. It's best to:
 
@@ -307,7 +307,7 @@ As much as copying someone else's settings simply may not work, people still ask
 
 #### Raspberry Pi 1
 
-~~~
+```
 arm_freq=900
 gpu_freq=400
 core_freq=400
@@ -315,11 +315,11 @@ sdram_freq=400
 sdram_schmoo=0x02000020
 over_voltage=2
 over_voltage_sdram=2
-~~~
+```
 
 #### Raspberry Pi 2
 
-~~~
+```
 total_mem=1024
 arm_freq=1000
 gpu_freq=500
@@ -328,11 +328,11 @@ sdram_freq=500
 sdram_schmoo=0x02000020
 over_voltage=2
 over_voltage_sdram=2
-~~~
+```
 
 #### Raspberry Pi 3
 
-~~~
+```
 total_mem=1024
 arm_freq=1300
 gpu_freq=500
@@ -341,11 +341,11 @@ sdram_freq=500
 sdram_schmoo=0x02000020
 over_voltage=2
 over_voltage_sdram=2
-~~~
+```
 
 #### Raspberry Pi Zero
 
-~~~
+```
 arm_freq=1000
 gpu_freq=500
 core_freq=500
@@ -353,53 +353,53 @@ sdram_freq=500
 sdram_schmoo=0x02000020
 over_voltage=6 (default)
 over_voltage_sdram=2
-~~~
+```
 
 ## Measurement Tools
 
 To display a Frames Per Second counter in RetroArch cores to see the effect on emulation speed, edit `/opt/retropie/configs/all/retroarch.cfg` and set:
 
-~~~
+```
 fps_show = "true"
-~~~
+```
 
 You can [SSH](SSH.md) into your Pi while playing a game and run these commands to measure the effect of normal operation.
 
 The temperature of the SoC can be queried with the command:
 
-~~~
+```
 vcgencmd measure_temp
-~~~
+```
 
 The currently applied `config.txt` parameters which differ from default can be queried with:
 
-~~~
+```
 vcgencmd get_config int | egrep "(arm|core|gpu|sdram)_freq|over_volt"
-~~~
+```
 
 The current frequency of the components can be queried with (remember they only increase speed under load unless using `force_turbo`):
 
-~~~
+```
 for src in arm core h264 isp v3d; do echo -e "$src:\t$(vcgencmd measure_clock $src)"; done
-~~~
+```
 
 The current voltages of the components can be queried with:
 
-~~~
+```
 for id in core sdram_c sdram_i sdram_p ; do echo -e "$id:\t$(vcgencmd measure_volts $id)"; done
-~~~
+```
 
 CPU usage of currently-running processes can be viewed with
 
-~~~
+```
 top
-~~~
+```
 
 A nicer display of CPU usage can be installed with `sudo apt update && sudo apt install htop` and then:
 
-~~~
+```
 htop
-~~~
+```
 
 ## Storage Overclocking
 
@@ -415,15 +415,15 @@ It is recommended *not* to try this with a regular non-UHS SDHC card.
 
 The sdcard reader speed can be increased in `/boot/config.txt` with the following line and a reboot:
 
-~~~
+```
 dtparam=sd_overclock=100
-~~~
+```
 
 Once booted, the sdcard reader frequency can be queried with:
 
-~~~
+```
 sudo grep clock /sys/kernel/debug/mmc0/ios
-~~~
+```
 
 Spotting a bad sdcard overclock can be very difficult, as the sdcard will probably write corrupted data and everything will appear to work fine, you won't notice the data is corrupt until you access it again later on.
 
@@ -437,32 +437,38 @@ For example, setting 100MHz on a Pi 3 results in 100MHz, but setting 99MHz actua
 
 #### Overclocking
 
-* http://elinux.org/RPiconfig#Overclocking (some outdated info for Pi 1, not Pi 2/3/Zero)
-* Official Pi Foundation forums thread (long): https://www.raspberrypi.org/forums/viewtopic.php?f=29&t=6201
-* http://linuxonflash.blogspot.com/2015/02/a-look-at-raspberry-pi-2-performance.html
-* Raspberry Pi 3 overclocking: https://haydenjames.io/raspberry-pi-3-overclock/
+* <http://elinux.org/RPiconfig#Overclocking> (some outdated info for Pi 1, not Pi 2/3/Zero)
+* Official Pi Foundation forums thread (long): <https://www.raspberrypi.org/forums/viewtopic.php?f=29&t=6201>
+* <http://linuxonflash.blogspot.com/2015/02/a-look-at-raspberry-pi-2-performance.html>
+* Raspberry Pi 3 overclocking: <https://haydenjames.io/raspberry-pi-3-overclock/>
 
 #### Cooling
 
-* ExplainingComputers video series: [1](https://www.youtube.com/watch?v=e6okZKRwnTQ), [2](https://www.youtube.com/watch?v=5Ud-grj4Zl0), [3](https://www.youtube.com/watch?v=1AYGnw6MwFM0), [4](https://www.youtube.com/watch?v=WfQMLInuwws)
-* https://github.com/superjamie/lazyweb/wiki/Raspberry-Pi-Cooling
+* <https://github.com/superjamie/lazyweb/wiki/Raspberry-Pi-Cooling>
+* ExplainingComputers video series:
+
+<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/e6okZKRwnTQ" title="Raspberry Pi 3: CPU Temperature Tests & Heatsink" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; allowfullscreen"></iframe>
+
+<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/5Ud-grj4Zl0" title="Raspberry Pi 3: Fan and Cooling Tests" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; allowfullscreen"></iframe>
+
+<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/WfQMLInuwws" title="Raspberry Pi 3: More Extreme Cooling" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; allowfullscreen"></iframe>
 
 #### Power
 
-* https://www.raspberrypi.org/help/faqs/#powerReqs
-* http://www.righto.com/2012/10/a-dozen-usb-chargers-in-lab-apple-is.html
-* https://github.com/superjamie/lazyweb/wiki/Raspberry-Pi-Power
-* http://www.calculator.net/voltage-drop-calculator.html
-* http://www.powerstream.com/Wire_Size.htm
+* <https://www.raspberrypi.org/help/faqs/#powerReqs>
+* <http://www.righto.com/2012/10/a-dozen-usb-chargers-in-lab-apple-is.html>
+* <https://github.com/superjamie/lazyweb/wiki/Raspberry-Pi-Power>
+* <http://www.calculator.net/voltage-drop-calculator.html>
+* <http://www.powerstream.com/Wire_Size.htm>
 
 #### SDcards
 
-* https://en.wikipedia.org/wiki/Secure_Digital#Ultra_High_Speed_.28UHS.29_bus
-* http://www.jeffgeerling.com/blog/2016/how-overclock-microsd-card-reader-on-raspberry-pi-3
-* https://www.reddit.com/r/raspberry_pi/comments/4aoc3r/how_to_overclock_the_microsd_card_reader_on_a/
+* <https://en.wikipedia.org/wiki/Secure_Digital#Ultra_High_Speed_.28UHS.29_bus>
+* <http://www.jeffgeerling.com/blog/2016/how-overclock-microsd-card-reader-on-raspberry-pi-3>
+* <https://www.reddit.com/r/raspberry_pi/comments/4aoc3r/how_to_overclock_the_microsd_card_reader_on_a/>
 
 #### Other
 
-* http://www.elinux.org/RPI_vcgencmd_usage
-* https://github.com/nezticle/RaspberryPi-BuildRoot/wiki/VideoCore-Tools
+* <http://www.elinux.org/RPI_vcgencmd_usage>
+* <https://github.com/nezticle/RaspberryPi-BuildRoot/wiki/VideoCore-Tools>
 * [Extra 16M memory on Pi2/Pi3](https://www.raspberrypi.org/forums/viewtopic.php?f=29&t=180420)

--- a/docs/Overscan.md
+++ b/docs/Overscan.md
@@ -18,7 +18,7 @@ Settings -> All Settings -> Picture -> Setting for aspect ratio -> Just Scan
 Select "On"
 
 ### Pioneer
-Look for "Dot by Dot". 
+Look for "Dot by Dot".
 
 (please add more examples if you work it out for your TV!)
 
@@ -42,13 +42,13 @@ Note that the line `disable_overscan=0` is not strictly necessary -- what is nec
 
 This should be a rarer scenario. In this case you need to do some configuration changes. Please consult this video:
 
-https://www.youtube.com/watch?v=AYB6r7q9JkU
+<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/AYB6r7q9JkU" title="RetroPie: Overscan on the Raspberry Pi" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; allowfullscreen"></iframe>
 
 Summarised: You can fill the whole expanse of your screen by editing the overscan settings. Exit to the terminal with F4 or access your pi over [SSH](SSH.md)
 ```
 sudo nano /boot/config.txt
 ```
-uncomment (i.e. delete the `#` preceding the line) 
+uncomment (i.e. delete the `#` preceding the line)
 ```
 #disable_overscan=1
 ```
@@ -56,9 +56,9 @@ to
 ```
 disable_overscan=1
 ```
-save with `ctrl+x` 
+save with `ctrl+x`
 
-Then reboot. If it doesn't work then try messing with some of the other [overscan](http://elinux.org/R-Pi_Troubleshooting#Big_black_borders_around_small_image_on_HD_monitors) settings manually 
+Then reboot. If it doesn't work then try messing with some of the other [overscan](http://elinux.org/R-Pi_Troubleshooting#Big_black_borders_around_small_image_on_HD_monitors) settings manually
 
 ## The console looks good, but the picture is off for EmulationStation/RetroArch/etc!
 

--- a/docs/RetroArch-Configuration.md
+++ b/docs/RetroArch-Configuration.md
@@ -29,7 +29,7 @@ There are 3 main ways to configure input for RetroArch:
 
 ## AutoConfigurations
 
-RetroArch controls have been integrated into EmulationStation and will be the first thing you see when you boot from the RetroPie SD image the first time. You can also access it from the start menu within EmulationStation under the Configure Input option. Your joypad is automagically configured for libretro (RetroArch) emulators when you configure your controller in EmulationStation. You'll know if your controller has been automagically configured if you see a flash of yellow text on the bottom of the screen with your gamepad ID when you start a game.  
+RetroArch controls have been integrated into EmulationStation and will be the first thing you see when you boot from the RetroPie SD image the first time. You can also access it from the start menu within EmulationStation under the Configure Input option. Your joypad is automagically configured for libretro (RetroArch) emulators when you configure your controller in EmulationStation. You'll know if your controller has been automagically configured if you see a flash of yellow text on the bottom of the screen with your gamepad ID when you start a game.
 
 The following diagrams are for the 3 most common controllers: Super Nintendo, Xbox 360, and PlayStation 3. They can be used as a reference when configuring your controllers. Each emulator page on the wiki has a diagram of the original controller for its respective console that will correspond to the same inputs listed below.
 
@@ -71,7 +71,7 @@ input_y_btn = "3"
 input_left_axis = "-0"
 input_state_slot_decrease_axis = "-0"
 ```
-As seen above in the config for the USB SNES controller, each input on the controller has an associated value.  When setting up the controller in EmulationStation, these values are then assigned a respective action on RetroArch.  
+As seen above in the config for the USB SNES controller, each input on the controller has an associated value.  When setting up the controller in EmulationStation, these values are then assigned a respective action on RetroArch.
 
 For example, suppose the "A" button on a USB SNES controller has a value of "1."  When setting up the controller, EmulationStation would prompt you to press the "A" button on your controller.  Pressing the "A" button would then record into the config file as `input_a_btn = "1"`, so RetroArch will know that the "A" button on your physical controller corresponds to the "A" button on RetroArch's virtual controller, the RetroPad.  Therefore, the next time you play a game such as Super Mario Bros. pressing the "A" button will tell RetroArch to press the "A" button on its RetroPad, causing Mario to jump.  If you accidentally pressed the "B" button with a value of "2" during setup when it prompted for "A," then it would be recorded into the config file as `input_a_btn = "2"`, so if you want to jump in Super Mario Bros., you would have to press "B" on your controller.
 
@@ -98,8 +98,8 @@ If you want to edit the entries in the .cfg file for your controller, you will n
 
 On the other hand, maybe you are not sure if the values in the .cfg file is correct or the file is missing entries for buttons that are available on your own controller, such as a "Home" button.  You can run _jstest_ (joystick test) in the terminal by selecting _Quit EmulationStation_ (a keyboard will be required for the following steps).
 
-In the terminal, type and enter     
-`jstest /dev/input/js0`     
+In the terminal, type and enter    
+`jstest /dev/input/js0`
 
 Replace js0 with js1, js2, js3, etc. as needed if not detected.
 
@@ -111,7 +111,7 @@ Using these values, you can edit the .cfg file for that controller as needed.  F
 
 **Video Tutorial**
 
-<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/DBnKFRflEV4" title="RetroPie: Using hotkeys in Retroarch" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/DBnKFRflEV4" title="RetroPie: Using hotkeys in Retroarch" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; allowfullscreen"></iframe>
 
 
 ## Hardcoded Configurations
@@ -149,7 +149,7 @@ Here, SYSTEMNAME is `atari2600`, `snes`, etc. All settings in these files will o
 ([example](RetroArch-Configuration#example-per-system-control-override-retroarchcfg))
 
 The `ROMNAME` includes the original file extension before the `.cfg`, e.g. `supermariobros.zip.cfg` These configurations are used when starting this specific ROM.
- 
+
 ### Custom RetroArch Override Examples
 
 #### Example Default Per-System retroarch.cfg
@@ -191,8 +191,8 @@ input_player2_r_btn = 5
 input_player2_start_btn = 9
 input_player2_select_btn = 8
 
-# Axis for RetroArch D-Pad. 
-# Needs to be either '+' or '-' in the first character signaling either positive or negative direction of the axis, then the axis number. 
+# Axis for RetroArch D-Pad.
+# Needs to be either '+' or '-' in the first character signaling either positive or negative direction of the axis, then the axis number.
 input_player1_up_axis = -1
 input_player1_down_axis = +1
 input_player1_left_axis = -0
@@ -229,7 +229,7 @@ config_save_on_exit = false
 
 ## Core Input Remapping
 
-Core Input Remapping differs from the other two methods as it remaps how the core receives input rather than how the gamepad is coded, for example you can tell the snes core to switch button A and B on the controller for gameplay, but you can still use "A" to select in the RGUI and "B" to go back where as hard-coding would make B select and A back. Core Remapping is much more practical than hard-coded mapping but is limited to the cores that support it. 
+Core Input Remapping differs from the other two methods as it remaps how the core receives input rather than how the gamepad is coded, for example you can tell the snes core to switch button A and B on the controller for gameplay, but you can still use "A" to select in the RGUI and "B" to go back where as hard-coding would make B select and A back. Core Remapping is much more practical than hard-coded mapping but is limited to the cores that support it.
 
 * Start a game of the system you want to remap the buttons
 * Invoke RGUI (**Hotkey+X** with player 1)
@@ -249,15 +249,13 @@ Remaps are saved as `.rmp` files in directory:
 
 ### Video Tutorials
 
-<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/liJKFUZX4PM" title="Remapping your controller" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/liJKFUZX4PM" title="Remapping your controller" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; allowfullscreen"></iframe>
 
-<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/fcRVcPkpLfQ" title="Testing your joystick" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/fcRVcPkpLfQ" title="Testing your joystick" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; allowfullscreen"></iframe>
 
+<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/AhkEnDdygbQ" title="Configuring USB Controllers With Retroarch" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; allowfullscreen"></iframe>
 
-<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/AhkEnDdygbQ" title="Configuring USB Controllers With Retroarch" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-
-
-<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/IjEA85BUDKs" title="XBox 360 Wireless Controller Configuration" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/IjEA85BUDKs" title="XBox 360 Wireless Controller Configuration" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; allowfullscreen"></iframe>
 
 ### Default Core Controls for All Emulators
 

--- a/docs/Runcommand.md
+++ b/docs/Runcommand.md
@@ -22,7 +22,7 @@ The second two options select video modes for the current system or ROM. This pr
 
 ### Configuring Runcommand
 
-You can enable and disable different functions of the Runcommand Launch Menu. This is configured via RetroPie-Setup or via the runcommand configuration option in the RetroPie area of Emulation Station. 
+You can enable and disable different functions of the Runcommand Launch Menu. This is configured via RetroPie-Setup or via the runcommand configuration option in the RetroPie area of Emulation Station.
 
 <img title="Runcommand configuration options" src="https://user-images.githubusercontent.com/31816814/85050776-43955d00-b19f-11ea-98a1-279faded0f3d.png" width="80%">
 
@@ -53,7 +53,9 @@ You can also automatically generate launching images based on emulationstation t
 
 **"Manage packages" >> "Manage experimental packages" >> "launchingimages" >> "Install from binary"**
 
-After installing you can use the tool going to RetroPie-Setup main menu and choose **Configuration / tools >> launchingimages** and then follow the instructions on screen. [Here is a nice video tutorial about this tool](https://www.youtube.com/watch?v=3wc4daHBLNE).
+After installing you can use the tool going to RetroPie-Setup main menu and choose **Configuration / tools >> launchingimages** and then follow the instructions on screen.
+
+<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/3wc4daHBLNE" title="How To Enable Launching images RetroPie" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; allowfullscreen"></iframe>
 
 The launching images can also be used in a per game basis. The image must be placed at `$HOME/RetroPie/roms/SYSTEM_NAME/images/` and named as `RomName-launching.png` (or `.jpg`), where `RomName` must be the exact name of the ROM minus the trailing extension.
 

--- a/docs/Running-ROMs-from-a-USB-drive.md
+++ b/docs/Running-ROMs-from-a-USB-drive.md
@@ -30,14 +30,14 @@ Before proceeding, make sure the `usbromservice` (Optional packages section) is 
 
 **Note:** if you have a large ROM collection already on the SD card it will copy all of the ROMs too so make sure your USB is large enough. It is easiest if you haven't added any roms yet.
 
-Once the folder structure is copied over the USB will be mounted over the RetroPie folder so any ROMs you add to your Pi will be run off of the USB. 
+Once the folder structure is copied over the USB will be mounted over the RetroPie folder so any ROMs you add to your Pi will be run off of the USB.
 
 **Note: XU4 owners**
 The XU4 and its OS do not respond the same as the Raspberry Pi with Raspbian and it does not provide a way to know when the sync is completed. It is recommended that you allow a decent amount of time for the process to sync.
 
 ### Video Tutorial
 
-<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/KBhDmGaTQG8" title="Running Roms from USB" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/KBhDmGaTQG8" title="Running Roms from USB" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; allowfullscreen"></iframe>
 
 ## Manual Mount
 
@@ -119,7 +119,7 @@ UUID=E44B-FC4E  /home/pi/RetroPie      vfat    nofail,user,uid=pi,gid=pi 0      
 In the case of errors with ext4 file systems use
 ```
 UUID="XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXX" /home/pi/RetroPie ext4 nofail,defaults 0    0
-``` 
+```
 
 In the case you want to allow execution of file with fat32 file system (E.g : OpenBOR), use
 ```

--- a/docs/Scraper.md
+++ b/docs/Scraper.md
@@ -1,4 +1,4 @@
-Scraping is a way to get metadata, boxart and video previews (snapshots) for your games from the internet. If the scraper isn't working either you are not connected to the Internet or source site may be down or overloaded and in that case you'll just have to wait until it comes back up. 
+Scraping is a way to get metadata, boxart and video previews (snapshots) for your games from the internet. If the scraper isn't working either you are not connected to the Internet or source site may be down or overloaded and in that case you'll just have to wait until it comes back up.
 
 Scraping adds extra information to the game - Publisher, Developer, Release year, Genre, Description, Number of Players supported and Rating.
 
@@ -22,7 +22,7 @@ EmulationStation has a built in scraper that pulls from [TheGamesDB](http://theg
 
 ![scrapermenu3](https://cloud.githubusercontent.com/assets/10035308/10713295/3b237434-7a74-11e5-8c30-68d76b67388e.png)
 
-![scrapermenu4](https://cloud.githubusercontent.com/assets/10035308/10713292/0f9360cc-7a74-11e5-8784-b1f2555a785f.png) 
+![scrapermenu4](https://cloud.githubusercontent.com/assets/10035308/10713292/0f9360cc-7a74-11e5-8784-b1f2555a785f.png)
 
 ![scrapermenu5](https://cloud.githubusercontent.com/assets/10035308/10713306/b89d2d56-7a74-11e5-9415-485b1b5dbc0f.png)
 
@@ -69,12 +69,12 @@ Scraper is started from inside the Retropie Setup Menu. Navigate to **Manage Pac
 
 - **Max Image Width/Height:** Specify the max image width or height to scrape.
 
-- **Console Source:** Choose which database to scrape for console games: 
+- **Console Source:** Choose which database to scrape for console games:
   * thegamesdb.net (default)
   * ScreenScraper.fr
   * OpenVGDB
 
-- **Arcade Source:** Choose which database to scrape for arcade/mame games: 
+- **Arcade Source:** Choose which database to scrape for arcade/mame games:
   * mamedb.blu-ferret.co.uk (default)
   * ScreenScraper.fr
   * ArcadeItalia.net
@@ -89,11 +89,10 @@ Scraper is started from inside the Retropie Setup Menu. Navigate to **Manage Pac
 - **Update scraper to the latest version:** This updates the scraper to the latest version.
 
 ### Scraping videos
-Here is a video showing how to scrape videos using the Steven Selph's Scraper
-<a href="https://youtube.com/watch?v=rj1841sL8ro
-" target="_blank"><img src="https://i.ytimg.com/vi/rj1841sL8ro/maxresdefault.jpg" 
-alt="Scraping Videos"/></a>
 
+Here is a video showing how to scrape videos using the Steven Selph's Scraper
+
+<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/rj1841sL8ro" title="How To Scrape Videos In RetroPie Using Steven Selph's Scraper" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; allowfullscreen"></iframe>
 
 ### Advanced Configuration
 
@@ -110,7 +109,7 @@ and an images folder with:
 `Super Mario World (USA)-image.png`
 (If you dont want to append the -image part on the filename you can use `-image_suffix=`)
 
-and I ran 
+and I ran
 
 `/opt/retropie/supplementary/scraper/scraper -img_format=png -add_not_found=true -download_images=false`
 
@@ -247,7 +246,7 @@ For a more thorough description of any functionality described here, please chec
 
 ### Installation
 
-1. Quit EmulationStation (from the start menu or press F4) and type 
+1. Quit EmulationStation (from the start menu or press F4) and type
    `sudo ~/RetroPie-Setup/retropie_setup.sh`.
 2. Choose **Manage Packages** then **Manage optional packages**.
 3. Select `skyscraper` and install the package.
@@ -257,7 +256,7 @@ Make sure to update to the latest version of Retropie-Setup script if you don't 
 
 ### Using Skyscraper
 
-**Skyscraper** can be used to generate scraping information for both [EmulationStation](EmulationStation.md) and [AttractMode](http://attractmode.org). Installing `skyscraper` as a RetroPie package will automatically configure it for EmulationStation, but if you wish to use it for generating **AttractMode** metadata, you can use **Skyscraper** from the command line. 
+**Skyscraper** can be used to generate scraping information for both [EmulationStation](EmulationStation.md) and [AttractMode](http://attractmode.org). Installing `skyscraper` as a RetroPie package will automatically configure it for EmulationStation, but if you wish to use it for generating **AttractMode** metadata, you can use **Skyscraper** from the command line.
 
 Check the [official documentation](https://github.com/muldjord/skyscraper/blob/master/docs/CLIHELP.md) for a list of all command line options.
 
@@ -274,7 +273,7 @@ Scraping your ROMs and games consists of at least 2 actions:
 
 When using the **Skyscraper** module from the RetroPie-Setup script, the following actions are available in the menu:
 
-- **Gather resources:** This will gather information/media only for the systems you choose.  
+- **Gather resources:** This will gather information/media only for the systems you choose.
   Press <kbd>Space</kbd> to select each system you wish to include and <kbd>OK</kbd> to start scraping.
 
 - **Gathering source:** Choose from a menu which source to use for gathering information and media for your ROMs:
@@ -286,38 +285,38 @@ When using the **Skyscraper** module from the RetroPie-Setup script, the followi
   * ONLINE: adb.arcadeitalia.net
   * LOCAL: esgamelist - Scrapes and caches data from an EmulationStation gamelist.xml located at `$HOME/RetroPie/roms/[platform]/gamelist.xml` or `~/.skyscraper/import/[platform]/gamelist.xml`
   * LOCAL: import -- imports resources into the resource cache. Read more about this [here](https://github.com/muldjord/skyscraper/blob/master/docs/IMPORT.md).
-  
+
   **NOTE:** Some online sources require a username/password for using them. You can add this information by editing the `config.ini` configuration file (from the **Advanced options** menu).
-  
+
   **INFO:** **Skyscraper** supports IGDB and MobyGames as gathering sources, but they are not integrated into the RetroPie script menu. If you wish to use them, you'll have to use it from the command line.
 
 - **Gathering options** is a sub-menu used to configure various aspects of the gathering phase and of the information added to the cache. You can also use this sub-menu to remove information from the cache, in order to free up space or get rid of unwanted information.
 
-  * _Cache screenshots:_ toggles the download and caching of screenshots from the scraping source into the resource cache.  
+  * _Cache screenshots:_ toggles the download and caching of screenshots from the scraping source into the resource cache.
   Default: _Enabled_
 
-  * _Cache covers:_ toggles the download and caching of covers from the scraping source into the resource cache.  
+  * _Cache covers:_ toggles the download and caching of covers from the scraping source into the resource cache.
   Default: _Enabled_
 
-  * _Cache wheels:_ toggles the download and caching of wheels from the scraping source into the resource cache.  
+  * _Cache wheels:_ toggles the download and caching of wheels from the scraping source into the resource cache.
   Default: _Enabled_
 
-  * _Cache marquees:_ toggles the download and caching of marquees from the scraping source into the resource cache.  
+  * _Cache marquees:_ toggles the download and caching of marquees from the scraping source into the resource cache.
   Default: _Enabled_
-  
+
   * _Scrape only missing:_ runs the scraper only for games/roms without any scraped information/media in the resource cache.
   Default: _Disabled_
 
-  * _Force cache refresh:_ **Skyscraper** caches the media retrieved from online sources to speed up scraping and to combine multiple sources of information to give you the best scraped information available. This option forces the scraper to bypass the resource cache and re-download the resources from the online sources during the gathering action.  
-  Default: _Disabled_.  
+  * _Force cache refresh:_ **Skyscraper** caches the media retrieved from online sources to speed up scraping and to combine multiple sources of information to give you the best scraped information available. This option forces the scraper to bypass the resource cache and re-download the resources from the online sources during the gathering action.
+  Default: _Disabled_.
   **NOTE**: Use this option sparingly. **Skyscraper** automatically downloads missing media for new ROMs, so it's only needed if your really want to re-download the ROM media from online sources.
 
-  * **Purge commands**  
-    **Skyscraper** caches locally the media downloaded from online sources. In time, this cache can grow and consume a considerable amount of disk space - especially if videos have been enabled. The cache size is displayed on top in this menu screen.  
+  * **Purge commands**
+    **Skyscraper** caches locally the media downloaded from online sources. In time, this cache can grow and consume a considerable amount of disk space - especially if videos have been enabled. The cache size is displayed on top in this menu screen.
     You can delete the files from the cache using the following actions available in this menu:
     * **Vacuum chosen platform:** deletes the locally cached resources that don't have a ROM/Game file anymore. Useful to clean up space after deleting ROMs.
     * **Purge chosen platform:** deletes all the locally cached resources for a chosen platform.
-    * **Purge all platforms:** deletes all locally cached resources, for all platforms.  
+    * **Purge all platforms:** deletes all locally cached resources, for all platforms.
     **NOTE:** use these options with care, they will completely remove the cached resources. Generating game lists after you've cleared the cache requires you to re-download the media from the scraping sources all over again.
 
 - **Generate game list(s)** This will generate the EmulationStation game list(s) for the systems you choose using all previously cached resources. Press Space to select the system(s) you wish to include and OK to start the generator..
@@ -327,34 +326,34 @@ When using the **Skyscraper** module from the RetroPie-Setup script, the followi
   * _ROM Names:_ Choose how to display the ROM name in EmulationStation:
     * **Source name** use the name pulled from the scraping source (_default_).
     * **Filename** use the file name of the ROM.
-  * _Remove bracket info:_ Choose to remove (**Enabled**) or keep (**Disabled**) the text between brackets. If the name of the ROM is `Super Mario World (USA)[!].sfc`, enabling this option will make the ROM show as `Super Mario World` in EmulationStation. Conversely, when disabled, the text between brackets will be added to the ROM's name in the gamelist.  
+  * _Remove bracket info:_ Choose to remove (**Enabled**) or keep (**Disabled**) the text between brackets. If the name of the ROM is `Super Mario World (USA)[!].sfc`, enabling this option will make the ROM show as `Super Mario World` in EmulationStation. Conversely, when disabled, the text between brackets will be added to the ROM's name in the gamelist.
   Default: _Enabled_.
   * _Use ROM folders for gamelist and media_: Toggle the location where the scraper will generate the final `gamelist.xml` file for EmulationStation:
     * When _Enabled_, the `gamelist.xml` and the media will be written to the ROMs folder.
-    * When _Disabled_,the `gamelist.xml` and the media will be written to the EmulationStation configuration folder - `$HOME/.emulationstation/gamelists` and `$HOME/.emulationstation/downloaded_media`.  
+    * When _Disabled_,the `gamelist.xml` and the media will be written to the EmulationStation configuration folder - `$HOME/.emulationstation/gamelists` and `$HOME/.emulationstation/downloaded_media`.
   Default: _Disabled_
 
 - **Other commands and options**
-  * _Download Videos:_ Choose to toggle the download and caching of videos for the ROM names and also if videos are added to the game list for EmulationStation.  
-    Default: _Disabled_.  
+  * _Download Videos:_ Choose to toggle the download and caching of videos for the ROM names and also if videos are added to the game list for EmulationStation.
+    Default: _Disabled_.
   **NOTE:** Be aware that gathering and caching videos could take up a lot of disk space.
 
-  * _Advanced options_ is a separate sub-menu for advanced actions:  
+  * _Advanced options_ is a separate sub-menu for advanced actions:
     - Edit the [**config.ini**](https://github.com/muldjord/skyscraper/blob/master/docs/CONFIGINI.md) file.
     - Edit the [**artwork.xml**](https://github.com/muldjord/skyscraper/blob/master/docs/ARTWORK.md) file.
     - Edit the **aliasMap.csv** file.
 
   * _Check for Updates_ will check if a new **Skyscraper** release is available, giving you the option to update to that release.
-    
+
 ### Advanced Configuration
 
 #### Configuration files
 
-**Skyscraper** keeps its configuration files and downloaded resources cache in the `~/.skyscraper` folder. When installed through the RetroPie-Setup, this folder is also accesible via [Samba Shares](First-Installation#samba-shares) at 
+**Skyscraper** keeps its configuration files and downloaded resources cache in the `~/.skyscraper` folder. When installed through the RetroPie-Setup, this folder is also accesible via [Samba Shares](First-Installation#samba-shares) at
 
 ```
 \\retropie\configs\all\skyscraper
-``` 
+```
 
 If you wish to edit the configuration files or use the [Import](#import-your-own-media) module, you can do so directly on the system where RetroPie is installed or over the network from another computer.
 
@@ -384,13 +383,13 @@ You'll notice after adding lots of ROMs and scraping them that your boot and shu
 ### Where are my scraped media and metadata saved?
 
 Once your ROMs have been scraped, the scraped information will be located in two parts: the _Gamelist_ files (containing the ROMs metadata) and the downloaded _Media files_ (images and/or videos). Depending on the options chosen for each scraper, this information can be found in 2 possible places:
-  
+
 Scraper used|Gamelist|Media
 -|-|-
-EmulationStation | `/home/pi/.emulationstation/gamelists` | `/home/pi/.emulationstation/downloaded_images`  
+EmulationStation | `/home/pi/.emulationstation/gamelists` | `/home/pi/.emulationstation/downloaded_images`
 Scraper | <ul style='margin:0'><li>Default <br> `/home/pi/.emulationstation/gamelists` <li>Using **ROM folder for gamelists & images**<br> `/home/pi/RetroPie/roms/<system>`| <ul style='margin:0'><li>Default <br> `/home/pi/.emulationstation/downloaded_images` <li>Using **ROM folder for gamelists & images**<br> `/home/pi/RetroPie/roms/<system>/images`
 Skyscraper | <ul style='margin:0'><li>Default <br> `/home/pi/.emulationstation/gamelists` <li>Using **ROM folder for gamelists & media**<br> `/home/pi/RetroPie/roms/<system>`| <ul style='margin:0'><li>Default <br> `/home/pi/.emulationstation/downloaded_media` <li>Using **ROM folder for gamelists & media**<br> `/home/pi/RetroPie/roms/<system>/media`
-    
+
 
 The `/home/pi/.emulationstation` folder can also be accessed over [Samba Shares](First-Installation#samba-shares) at
 ```

--- a/docs/ScummVM.md
+++ b/docs/ScummVM.md
@@ -14,7 +14,7 @@ _ScummVM stands for Script Creation Utility for Maniac Mansion (VM stands for vi
 
 Accepted File Extensions: This is a tricky question as ScummVM has its own particular filesets and method of loading- but when all is said and done **.sh .svm** are the filetypes EmulationStation will read.
 
-ScummVM is very different to most romsets in that there are a set of files for each game. 
+ScummVM is very different to most romsets in that there are a set of files for each game.
 
 See the list here: http://wiki.scummvm.org/index.php/Datafiles
 
@@ -93,6 +93,4 @@ You can open the **options** in the scummvm launcher and change the graphics mod
 
 ## Video Tutorial:
 
-<a href="https://www.youtube.com/watch?v=txdiaZlDUEs" target="_blank"><img src="https://i.ytimg.com/vi_webp/txdiaZlDUEs/mqdefault.webp" 
-alt="ScummVM Configuration" width="300" height="180" border="10" /></a>
-
+<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/txdiaZlDUEs" title="Setting Up RetroPie 2.6: Configuring Scummvm" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; allowfullscreen"></iframe>

--- a/docs/Sega-CD.md
+++ b/docs/Sega-CD.md
@@ -11,7 +11,7 @@ The Sega CD was an add-on to the Sega Mega Drive/Genesis. It was released in 199
 | [lr-picodrive](https://github.com/libretro/picodrive) | segacd | .bin .chd .cue .iso .m3u | us_scd1_9210.bin, eu_mcd1_9210.bin, jp_mcd1_9112.bin | /opt/retropie/configs/segacd/retroarch.cfg |
 
 ## Emulators: [lr-genesis-plus-gx](https://github.com/libretro/Genesis-Plus-GX), [lr-picodrive](https://github.com/libretro/picodrive)
-**lr-genesis-plus-gx** is recommended for the Pi 2/3 as it has better accuracy. 
+**lr-genesis-plus-gx** is recommended for the Pi 2/3 as it has better accuracy.
 
 ## ROMS
 Accepted File Extensions: **.bin .chd .cue .iso**, **.m3u** for multi-disc games.    
@@ -23,7 +23,7 @@ Place your Sega CD ROMS (.chd .iso OR .bin AND .cue) in
 ```
 If you don't have the corresponding .cue file in the same folder as your .bin file, your game may not have sound.
 ### Multi-Disc games
-For multi-disc games using `.cue` or `.chd` format, you can create a `.m3u` playlist to be able to easily change discs from the RetroArch's _Disk Control_ menu. 
+For multi-disc games using `.cue` or `.chd` format, you can create a `.m3u` playlist to be able to easily change discs from the RetroArch's _Disk Control_ menu.
 
 To change the disc through RetroArch, from the "Quick Menu", enter "Disk Control", use the "Disk Cycle Tray Status" to open the virtual disk tray, change the disk number to the correct one, then use the "Disk Cycle Tray Status" to close the virtual disk tray.
 
@@ -64,7 +64,7 @@ lr-genesis-plus-gx and lr-picodrive have support for the CHD (V1-V5) archive for
 
 ### lr-picodrive
 
-The BIOS filename is: **us_scd1_9210.bin** 
+The BIOS filename is: **us_scd1_9210.bin**
 
 Place this lr-picodrive BIOS file in
 ```
@@ -80,17 +80,21 @@ Place this lr-genesis-plus-gx BIOS file in
 ```
 /home/pi/RetroPie/BIOS
 ```
-the alternate BIOS files above can be renamed: bios_CD_E.bin, bios_CD_J.bin (Europe and Japan respectively)  
-  
-Video Guide using lr-genesis-plus-gx: https://www.youtube.com/watch?v=PkktRuK8uWU
+the alternate BIOS files above can be renamed: bios_CD_E.bin, bios_CD_J.bin (Europe and Japan respectively)
+
+Video Guide using lr-genesis-plus-gx:
+
+<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/PkktRuK8uWU" title="RetroPie: Sega CD / Mega CD emulation on a Raspberry Pi" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; allowfullscreen"></iframe>
+
 
 ### Checksums
 
-| lr-picodrive filename | lr-Genesis-Plus-GX filename | No-Intro filename | md5sum |
-| :---: | :---: | :---: | :---: |
-| us_scd1_9210.bin | bios_CD_U.bin | [BIOS] Sega CD (USA) (v1.10).md | 2efd74e3232ff260e371b99f84024f7f |
-| eu_mcd1_9210.bin | bios_CD_E.bin | [BIOS] Mega-CD (Europe) (v1.00).md | e66fa1dc5820d254611fdcdba0662372 |
-| jp_mcd1_9112.bin | bios_CD_J.bin | [BIOS] Mega-CD (Asia) (v1.00S).md | bdeb4c47da613946d422d97d98b21cda |
+| lr-picodrive filename | lr-Genesis-Plus-GX filename |         No-Intro filename          |              md5sum              |
+| :-------------------: | :-------------------------: | :--------------------------------: | :------------------------------: |
+|   us_scd1_9210.bin    |        bios_CD_U.bin        |  [BIOS] Sega CD (USA) (v1.10).md   | 2efd74e3232ff260e371b99f84024f7f |
+|   eu_mcd1_9210.bin    |        bios_CD_E.bin        | [BIOS] Mega-CD (Europe) (v1.00).md | e66fa1dc5820d254611fdcdba0662372 |
+|   jp_mcd1_9112.bin    |        bios_CD_J.bin        | [BIOS] Mega-CD (Asia) (v1.00S).md  | bdeb4c47da613946d422d97d98b21cda |
+
 
 ## Controls
 

--- a/docs/Speed-Issues.md
+++ b/docs/Speed-Issues.md
@@ -108,4 +108,5 @@ Cases with fans are also available, with the fan usually powered by the 5V GPIO 
 * [Showcase of older emulator versions on Raspberry Pi 1](http://www.youtube.com/watch?v=rm3IuXeIfaw)
 * [ToadKing](http://www.raspberrypi.org/phpBB3/viewtopic.php?p=137827#p137827)
 * [ChadP](http://www.raspberrypi.org/phpBB3/viewtopic.php?p=156971#p156971)
-* [Comparison of cooling methods](https://www.youtube.com/watch?v=1AYGnw6MwFM)
+
+<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/1AYGnw6MwFM" title="Raspberry Pi 3: Extreme Passive Cooling" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; allowfullscreen"></iframe>

--- a/docs/TI-99.md
+++ b/docs/TI-99.md
@@ -2,7 +2,7 @@
 ![ti-99-logo](https://cloud.githubusercontent.com/assets/10035308/15901958/cd2fe5dc-2d62-11e6-9c22-7213d37ebc89.png)
 ***
 _The TI-99/4A was a home computer originally released by the Texas Instruments in 1981._
-*** 
+***
 
 | Emulator | Rom Folder | Extension | BIOS |  Controller Config |
 | :---: | :---: | :---: | :---: | :---: |
@@ -32,8 +32,7 @@ TI-99/Sim v0.14.0 and RetroPie V3.8.1
 
 [Updated Installation Instruction V.20](http://www.globeron.com/freedownload/services/TI99/TI-99-Sim-Installation-on-RaspberryPI2ModelB-RetroPieV381-DocV2.pdf)
 
-[Video Installation Overview](https://www.youtube.com/watch?v=3BT6eXlbO-Q)
-
+<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/3BT6eXlbO-Q" title="TI-99/4A on the RetroPie (using TI-99/Sim) - Setup and installation" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; allowfullscreen"></iframe>
 
 [Installation Instructions v1.0 (AtariAge)](http://atariage.com/forums/topic/250767-how-to-install-ti-994a-ti-99sim-on-retropie-v36-raspberry-pi2-or-pi3/#entry3491795)
 

--- a/docs/Validating,-Rebuilding,-and-Filtering-ROM-Collections.md
+++ b/docs/Validating,-Rebuilding,-and-Filtering-ROM-Collections.md
@@ -24,7 +24,7 @@ In order to verify or rebuild a set, you need its corresponding DAT file and a s
 * [Romulus](https://romulus.cc/) (Windows)
 * [RomVault](http://www.romvault.com/) (Windows & Linux)
 
-These Windows tools can be run on Linux (x86) using [Wine](https://www.winehq.org/). RomVault can be run natively on Linux using Mono. 
+These Windows tools can be run on Linux (x86) using [Wine](https://www.winehq.org/). RomVault can be run natively on Linux using Mono.
 
 ***
 
@@ -33,7 +33,7 @@ These Windows tools can be run on Linux (x86) using [Wine](https://www.winehq.or
 ### Filtering console collections
 
 #### No-Intro 1 Game, 1 ROM DATs (aka Parent-Clone DATs)
-1G1R DATs (aka Parent-Clone DATs) allow you to create a '1 game, 1 ROM' collection from a full No-Intro set. For example, you can set ClrMamePro to filter your set based on a preference of USA ROMs > then EUR > then JPN. 
+1G1R DATs (aka Parent-Clone DATs) allow you to create a '1 game, 1 ROM' collection from a full No-Intro set. For example, you can set ClrMamePro to filter your set based on a preference of USA ROMs > then EUR > then JPN.
 
 The resulting set of ROMs will feature a USA version of a game whenever possible, then look for a EUR region ROM for that title, and finally use the JPN only if no USA or EUR ROMs are in the folder. All regions with releases in a given system are supported (in other words you could set a preference of Spain > Europe > USA > Italy > Japan > etc.)
 
@@ -59,8 +59,9 @@ The wiki pages for [MAME](MAME), [FB Neo](FinalBurn-Neo), and [Neo Geo](Neo-Geo)
 
 The remainder of this section of the docs is devoted to a demonstration of using ClrMamePro to rebuild and validate arcade ROM sets. The tutorial uses a MAME 0.37b5 collection as well as a PiFBA collection (in the video version) to demonstrate the process.
 
-* **[View the ClrMamePro video tutorial on YouTube](https://www.youtube.com/watch?v=_lssz2pAba8)**
-* **[Read the written ClrMamePro tutorial below](#written-clrmamepro-tutorial)**
+<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/_lssz2pAba8" title="Easy ClrMamePro Tutorial (Updated for RetroPie 3.3)" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; allowfullscreen"></iframe>
+
+**[Read the written ClrMamePro tutorial below](#written-clrmamepro-tutorial)**
 
 Before manipulating arcade ROMs, please be sure you are familiar with their unique terminology.
 
@@ -82,7 +83,7 @@ In addition to having a version number, arcade ROMs can be formatted four ways:
 
 ***
 
-###  ClrMamePro tutorial 
+###  ClrMamePro tutorial
 
 #### Step 1 - Back up your ROMs
 It is possible with ClrMamePro to change one or two options and when it runs it will delete all your existing ROMs. OK, not really - using the default options it will make backups of any files it removes, but it is still possible to mess up their ROMs beyond repair when getting started with ClrMamePro.
@@ -97,7 +98,7 @@ You can download all .DAT files for all arcade emulators [**HERE**](https://gith
 * Create a subdirectory `C:\retropie-dat-master\pifbaroms`
 
 #### Step 4 - Run ClrMamePro for the first time
-* Run `C:\clrmamepro\cmpro64.exe`.  The welcome screen explains that common first steps are to 1) Create a Profile, 2) Set up your paths and 3) Scan your ROMs. We will be doing things slightly differently, in order to leave your source ROMs intact.  
+* Run `C:\clrmamepro\cmpro64.exe`.  The welcome screen explains that common first steps are to 1) Create a Profile, 2) Set up your paths and 3) Scan your ROMs. We will be doing things slightly differently, in order to leave your source ROMs intact.
 * Click OK to the Welcome screen
 * Click **"Add DatFile..."** and open the MAME4ALL DAT file at `C:\retropie-dat-master\mame4all\MAME 0.37b5.dat`
 * Accept the default profile location of [PROFILES], click **"OK"**
@@ -119,7 +120,7 @@ At this point, you could scan the ROMs folder you just selected, but we just cre
 * Use the browse button **"..."** to select your source path. For example you might have a full set of MAME v0.156 ROMs - point ClrMamePro to that directory as your source.
 * When rebuilding there are three options: **Non-Merged, Merged, and Split**. (**NOTE**: Using Non-Merged ROMs is the most straightforward way to copy individual games to a RetroPie system.) In order to rebuild "Full Non-merged" ROM sets select "Non-Merged in this menu, then click the "Advanced" button and deselect "Separate BIOS sets".
 * Click **"Rebuild..."**.  Depending on the size of the directory you chose as a source, this could take some time
-* When ClrMamePro is finished rebuilding, you will see a window with statistics showing how many matching files were found, how many files were created and how many were skipped.  Click "OK" 
+* When ClrMamePro is finished rebuilding, you will see a window with statistics showing how many matching files were found, how many files were created and how many were skipped.  Click "OK"
 * Repeat for any other source paths you might have.  You can rebuild from multiple sources, but leave the Destination path the same
 * When finished, close the Rebuilder with the **"X"** in the upper right corner of the window
 

--- a/docs/Xbox-360-Controller.md
+++ b/docs/Xbox-360-Controller.md
@@ -6,7 +6,7 @@ To pair your controller(s) with the wireless receiver:
 
 - turn on your wireless Xbox 360 controller (hold down the Guide button)
 - press the connect button on the receiver (green light will start flash)
-- then press the tiny connect button on the top of the controller 
+- then press the tiny connect button on the top of the controller
 - you will need to repeat these steps to pair each additional controller
 
 ## Automatic Configuration (Easiest)
@@ -64,7 +64,7 @@ input_l2_axis = "+2"
 
 **However, these incompatibilities are not an issue when [using xboxdrv as a calibration and key-mapping tool](Universal-Controller-Calibration-&-Mapping-Using-xboxdrv) for almost any gamepad, including the Xbox 360 controller. When used this way, it's even possible for both xpad and xboxdrv to coexist together.**
 
-Access the [RetroPie Setup Script](Updating-RetroPie) and navigate to **Manage Packages >> Manage Driver Packages >> xboxdrv** 
+Access the [RetroPie Setup Script](Updating-RetroPie) and navigate to **Manage Packages >> Manage Driver Packages >> xboxdrv**
 
 ![xboxdrv](https://cloud.githubusercontent.com/assets/10035308/12218229/d397607e-b6d6-11e5-8a99-f3106d60425a.png)
 
@@ -229,8 +229,8 @@ case "$1" in
     ;;
 esac
 ```
-`sudo chmod +x /etc/init.d/xboxdrv`  
-`sudo update-rc.d xboxdrv start 90 2 3 4 5 stop 90 0 1 6`  
+`sudo chmod +x /etc/init.d/xboxdrv`
+`sudo update-rc.d xboxdrv start 90 2 3 4 5 stop 90 0 1 6`
 You will also need a default configuration file. Save the following content to **/etc/default/xboxdrv**:
 ```
 # How many Controllers? (support up to 4 Controllers)
@@ -333,26 +333,23 @@ This is what makes the Xbox 360 controller the best for this project.
 Now, whenever you press the Xbox (guide) button on either controller 1 or 2, it will change the control scheme. For player 1, the controller starts up in normal mode. Hitting the Xbox button will change to player1.cfg. Hitting it again will enable mouse emulation. One more time will bring back normal operation. Controller 2 cycles between normal operation and player2.cfg. Controllers 3 and 4 are unaffected.
 
 
-Here's a little explanation of xboxdrv_player1.cfg (player2 is similar):
+Here's a little explanation of `xboxdrv_player1.cfg` (player 2 is similar):
 
-    Interface    | Mapped to   | Atari 800/5200 |    Commodore   |
-    -------------------------------------------------------------
-    Right Analog | Arrow Keys  | Menu Nav       | Menu Nav        
-    Left Analog  | Mouse       | Movement       |                 
-    D-Pad        | Joystick    |                | Joystick port 2 
-    -------------------------------------------------------------
-    A Button     | Right Ctrl  |                | Fire            
-    B Button     | Num Pad 0   | Fire           | Fire            
-    X Button     | Enter       |                | Return          
-    Y Button     | Space       | Space          | Space           
-    -------------------------------------------------------------
-    L1 Button    | F4          | Start Game     |                 
-    R1 Button    | F7          |                |                 
-    L2 Button    | PAGEUP      |                |                 
-    R2 Button    | CAPSLOCK    |                | Start Game      
-    --------------------------------------------------------------
-    Start        | F1          | Menu           | Menu            
-    Back         | Esc         | Esc            | Esc  
+| Interface    | Mapped to  | Atari 800/5200 | Commodore       |
+| ------------ | ---------- | -------------- | --------------- |
+| Right Analog | Arrow Keys | Menu Nav       | Menu Nav        |
+| Left Analog  | Mouse      | Movement       |                 |
+| D-Pad        | Joystick   |                | Joystick port 2 |
+| A Button     | Right Ctrl |                | Fire            |
+| B Button     | Num Pad 0  | Fire           | Fire            |
+| X Button     | Enter      |                | Return          |
+| Y Button     | Space      | Space          | Space           |
+| L1 Button    | F4         | Start Game     |                 |
+| R1 Button    | F7         |                |                 |
+| L2 Button    | PAGEUP     |                |                 |
+| R2 Button    | CAPSLOCK   |                | Start Game      |
+| Start        | F1         | Menu           | Menu            |
+| Back         | Esc        | Esc            | Esc             |
 
 
 ***


### PR DESCRIPTION
Looks massive but in essence it is the uniform usage of `<iframe ...>` for yt links, using the `youtube-nocookie` site.

I left  the `Bluetooth-Controller.md` page as-is regarding any youtube links as  it needs an overhaul in general.

Some minor issues also addressed:
-  Removal of trailing spaces
-  Some tables fixed in layout
