### PR TITLE
Fix: Current topic in ToC (right) has very little contrast in dark mode

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -18,6 +18,10 @@
     --md-code-font: SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",monospace;
 }
 
+[data-md-color-scheme="slate"] .md-nav__link.md-nav__link--active:not(:hover) {
+  color: var(--md-primary-fg-color--lightest);
+}
+
 .md-typeset table:not([class]) th:not([align]){text-align:left}.md-typeset table:not([class]) th{
   min-width:10rem;
   padding:1.2rem 1.6rem;


### PR DESCRIPTION
This enhances the visibility of the current topic in the table of contents (right of screen) when in dark mode (`slate`).
Without the patch the current topic was very difficult to read (if at all). With the patch it has the same behaviour as in the light mode (i.e. it has the same foreground color as topics to follow in the ToC).

Current situation:
![rp-docs-darkmode-toc-invisible](https://github.com/user-attachments/assets/1b700f68-2a4b-429c-a46c-8a7d7b6214d9)
